### PR TITLE
clearer definition of transaction

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -229,7 +229,7 @@ where $v$ is the account validity function:
 
 \subsection{The Transaction} \label{ch:transaction}
 
-A transaction (formally, $T$) is a single cryptographically-signed instruction sent by an actor external to Ethereum. An external actor can be a person (via a mobile device or desktop computer) or could be from a piece of automated software running on a server. There are two types of transactions: those which result in message calls and those which result in the creation of new accounts with associated code (known informally as `contract creation'). Both types specify a number of common fields:
+A transaction (formally, $T$) is a single cryptographically-signed instruction sent by a node in the Ethereum network. There are two types of transactions: those which result in message calls and those which result in the creation of new accounts with associated code (known informally as `contract creation'). Both types specify a number of common fields:
 
 \begin{description}
 \item[nonce] A scalar value equal to the number of transactions sent by the sender; formally $T_n$.


### PR DESCRIPTION
To me, an actor external to Ethereum is not a very clear definition. A transaction must come from a node in the network. I think this is a clearer definition, since an external actor can be almost everything. Also the examples of an external actor (mobile, desktop, server) is only a subset, any kind of computer connected to the network (="a node in the Ethereum network") can send a transaction (IoT devices, ...).