### PR TITLE
verify block number consistency

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -462,6 +462,7 @@ V(H) & \equiv & \mathtt{PoW}(H, H_n) \leqslant \frac{2^{256}}{H_d} \quad \wedge 
 & & H_d = D(H) \quad \wedge \\
 & & H_l = L(H) \quad \wedge \\
 & & H_s > {P(H)_H}_s \quad \wedge \\
+& & H_i = {P(H)_H}_i +1 \quad \wedge \\
 & & \lVert H_x \rVert \le 1024
 \end{eqnarray}
 


### PR DESCRIPTION
Although trivial, but I did not find it in the YP. The current block number always needs to be the previous block number + 1, in order to be a valid block.