### PR TITLE
Difficulty low limit

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1690,9 +1690,13 @@ Here given are the various exceptions to the state transition rules given in sec
 \toprule
 \multicolumn{5}{c}{\textbf{40s: Block Information}} \vspace{5pt} \\
 \textbf{Value} & \textbf{Mnemonic} & $\delta$ & $\alpha$ & \textbf{Description} \vspace{5pt} \\
-0x40 & {\small PREVHASH} & 0 & 1 & Get hash of most recent complete block. \\
-&&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv {I_H}_p$ \\
-&&&& $I_{H_p}$ is the previous block's hash. \\
+0x40 & {\small BLOCKHASH} & 10 & 1 & Get the hash of one of the 256 most recent complete blocks. \\
+&&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv A(I_{H_p}, \boldsymbol{\mu}_\mathbf{s}[0], 0)$ \\
+&&&& where $A$ is the hash of a block of a particular number, up to a maximum age.\\
+&&&& For a number greater than or equal to, or less than 256 below, the present block's\\
+&&&& number, 0 is left on the stack.\\
+&&&& $P(h, n, a) \equiv \begin{cases} 0 & \text{if} \quad n > H_n \vee a = 256 \vee h = 0 \\ H_h & \text{if} \quad n = H_n \\ P(H_p, n, a + 1) & \text{otherwise} \end{cases}$ \\
+&&&& and we assert the header $H$ can be determined from the hash given: $h = H_h$ \\
 \midrule
 0x41 & {\small COINBASE} & 0 & 1 & Get the block's coinbase address. \\
 &&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv {I_H}_b$ \\

--- a/Paper.tex
+++ b/Paper.tex
@@ -424,7 +424,8 @@ The canonical difficulty of a block of header $H$ is defined as $D(H)$:
 \begin{equation}
 D(H) \equiv \begin{cases}
 2^{22} & \text{if} \quad H_i = 0\\
-{P(H)_H}_d + \lfloor\frac{{P(H)_H}_d}{1024}\rfloor & \text{if} \quad H_s < {P(H)_H}_s + 8\\
+1024 & \text{if} \quad {P(H)_H}_d < 1024\\
+{P(H)_H}_d + \lfloor\frac{{P(H)_H}_d}{1024}\rfloor & \text{else if} \quad H_s < {P(H)_H}_s + 8\\
 {P(H)_H}_d - \lfloor\frac{{P(H)_H}_d}{1024}\rfloor & \text{otherwise}\\
 \end{cases}
 \end{equation}

--- a/Paper.tex
+++ b/Paper.tex
@@ -851,18 +851,13 @@ This states that the execution is in an exceptional halting state if there is in
 
 \subsubsection{Jump Destination Validity}
 
-We previously used $D$ as the function to determine the set of valid jump destinations given the code that is being run. We define this as:
-
-\begin{itemize}
-\item Any position in the code occupied by a {\small JUMPDEST} instruction.
-\item Any position $p$ in the code such that there exists a {\small PUSH} of the value $p$ immediately followed by a {\small JUMP} or {\small JUMPI}.
-\end{itemize}
+We previously used $D$ as the function to determine the set of valid jump destinations given the code that is being run. We define this as any position in the code occupied by a {\small JUMPDEST} instruction.
 
 All such positions must be on valid instruction boundaries, rather than sitting in the data portion of {\small PUSH} operations and must appear within the explicitly defined portion of the code (rather than in the implicitly defined {\small STOP} operations that trail it).
 
 Formally:
 \begin{equation}
-D(\mathbf{c}) \equiv (D_J(\mathbf{c, 0}) \cup D_P(\mathbf{c, 0})) \cap Y(\mathbf{c}, 0)
+D(\mathbf{c}) \equiv D_J(\mathbf{c, 0}) \cap Y(\mathbf{c}, 0)
 \end{equation}
 
 where:
@@ -879,28 +874,8 @@ D_J(\mathbf{c}, i) \equiv \begin{cases}
 D_J(\mathbf{c}, N(i, \mathbf{c}[i])) & \text{otherwise} \\
 \end{cases}
 \end{equation}
-\begin{equation}
-D_P(\mathbf{c}, i) \equiv \begin{cases}
-\{\} & \text{if} \quad i \geqslant |\mathbf{c}|  \\
-\{ p \} \cup D_P(\mathbf{c}, n) & \mathbf{c}[i] \in [\text{\small PUSH1}, \text{\small PUSH32}] \quad \wedge \\ & \mathbf{c}[n] \in \{ \text{\small JUMP}, \text{\small JUMPI} \} \\
-D_P(\mathbf{c}, n) & \text{otherwise}
-\end{cases}
-\end{equation}
 
-where, for the purposes of the final equation, $n$ is the next instruction index and $p$ is the {\small PUSH}$x$ instruction's associated data (the following $x$ bytes interpreted as a big endian unsigned):
-\begin{equation}
-n \equiv N(i, \mathbf{c}[i]) \\
-\end{equation}
-\begin{equation}
-p \equiv \begin{cases}
-\mathbf{c}[i + 1] & \text{if}\quad \mathbf{c}[i] = \text{\small PUSH1} \\
-2^8\mathbf{c}[i + 1] + \mathbf{c}[i + 2] & \text{if}\quad \mathbf{c}[i] = \text{\small PUSH2} \\
-\quad\quad\vdots & \quad\quad\vdots \\
-2^{240}\mathbf{c}[i + 1] + ... + \mathbf{c}[i + 32] & \text{if}\quad \mathbf{c}[i] = \text{\small PUSH32} \\
-\end{cases}
-\end{equation}
-
-and $N$ is the next valid instruction position in the code, skipping the data of a {\small PUSH} instruction, if any:
+where $N$ is the next valid instruction position in the code, skipping the data of a {\small PUSH} instruction, if any:
 \begin{equation}
 N(i, w) \equiv \begin{cases}
 i + w - \text{\small PUSH1} + 2 & \text{if} \quad w \in [\text{\small PUSH1}, \text{\small PUSH32}] \\


### PR DESCRIPTION
If difficulty goes below 1024, then it will stay there forever. This is theoretically possbile after 9104 more difficulty decreasing  blocks than increasing blocks (starting with 2**22):
<pre><code>
def f(d):
    return d - d // 1024

diff = 2^22
counter = 0
while diff >= 1024:
    diff = f(diff)
    counter += 1
    
print "After", str(counter), "steps, you may reach the limit"
</code></pre>

>After 9104 steps, you may reach the limit