### PR TITLE
Improve 0x40 BLOCKHASH function definition

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1719,12 +1719,13 @@ TODO: Whenever a stack item is used as an address, it should be assumed it is th
 \multicolumn{5}{c}{\textbf{40s: Block Information}} \vspace{5pt} \\
 \textbf{Value} & \textbf{Mnemonic} & $\delta$ & $\alpha$ & \textbf{Description} \vspace{5pt} \\
 0x40 & {\small BLOCKHASH} & 1 & 1 & Get the hash of one of the 256 most recent complete blocks. \\
-&&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv A(I_{H_p}, \boldsymbol{\mu}_\mathbf{s}[0], 0)$ \\
-&&&& where $A$ is the hash of a block of a particular number, up to a maximum age.\\
-&&&& For a number greater than or equal to, or less than 256 below, the present block's\\
-&&&& number, 0 is left on the stack.\\
-&&&& $P(h, n, a) \equiv \begin{cases} 0 & \text{if} \quad n > H_n \vee a = 256 \vee h = 0 \\ H_h & \text{if} \quad n = H_n \\ P(H_p, n, a + 1) & \text{otherwise} \end{cases}$ \\
-&&&& and we assert the header $H$ can be determined from the hash given: $h = H_h$ \\
+&&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv P(I_{H_p}, \boldsymbol{\mu}_\mathbf{s}[0], 0)$ \\
+&&&& where $P$ is the hash of a block of a particular number, up to a maximum age.\\
+&&&& 0 is left on the stack if the looked for block number is greater than the current block number \\
+&&&& or more than 256 blocks behind the current block. \\
+&&&& $P(h, n, a) \equiv \begin{cases} 0 & \text{if} \quad n > H_i \vee a = 256 \vee h = 0 \\ h & \text{if} \quad n = H_i \\ P(H_p, n, a + 1) & \text{otherwise} \end{cases}$ \\
+&&&& and we assert the header $H$ can be determined as its hash is the parent hash \\
+&&&& in the block following it. \\
 \midrule
 0x41 & {\small COINBASE} & 0 & 1 & Get the block's coinbase address. \\
 &&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv {I_H}_b$ \\


### PR DESCRIPTION
* Correct reference to the P helper function
* Correct reference to block header number Hi
* Clarify the condition for when 0 is left on the stack
* Use h instead of Hh when refering to the current block hash