### PR TITLE
message call to account with no code

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -711,7 +711,7 @@ The account's associated code (identified as the fragment whose Keccak hash is $
 
 \begin{eqnarray}
 \boldsymbol{\sigma}' & \equiv & \begin{cases}
-\boldsymbol{\sigma}_1 & \text{if} \quad \mathbf{o} = \varnothing \\
+\boldsymbol{\sigma}_1 & \text{if} \quad \boldsymbol{\sigma}[c]_c = \mathtt{\tiny KEC}(()) \\
 \boldsymbol{\sigma}^{**} & \text{otherwise}
 \end{cases} \\
 (\boldsymbol{\sigma}^{**}, g', \mathbf{s}, \mathbf{o}) & \equiv & \begin{cases}


### PR DESCRIPTION
May be I misunderstand something here. But why was the previously defined criteria for doing nothing but transfering value at a message call, that the output data is empty?
I can make a transaction to a contract with code, which needs to get executed, also without having any output data. Therefore I changed it to "account with no code".