### PR TITLE
Fix typo in revert-state-upon-exception equation 91

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -715,7 +715,7 @@ The account's associated code (identified as the fragment whose Keccak hash is $
 
 \begin{eqnarray}
 \boldsymbol{\sigma}' & \equiv & \begin{cases}
-\boldsymbol{\sigma}_1 & \text{if} \quad \mathbf{o} = \varnothing \\
+\boldsymbol{\sigma}_1 & \text{if} \quad \boldsymbol{\sigma}^{**} = \varnothing \\
 \boldsymbol{\sigma}^{**} & \text{otherwise}
 \end{cases} \\
 (\boldsymbol{\sigma}^{**}, g', \mathbf{s}, \mathbf{o}) & \equiv & \begin{cases}


### PR DESCRIPTION
This equation previously read:

    sigma' = sigma1 if o==emptyset, else sigma**

I think that "o" is never the empty set: my reading of eqs 92, 103, 109, 110, 113, and 118 leads me to believe that o will be:

* () if a Z=True "exceptional halt" occurs (out-of-gas, bad-instruction,
  stack-underflow, bad-jumpdest, call-stack-overflow)
* () if STOP or SUICIDE instructions are executed
* () if RETURN is executed with length-to-return = 0
* (stuff) is RETURN is executed with length-to-return > 0

(noting that `()` is empty-**sequence**, which is distinct from the zero-with-slash that is empty-**set**)

And I think that the revert-to-sigma1 behavior is intended to only occur when an exceptional halt occurs. If we test `sigma**` instead of "o", I think we'll get the intended behavior.