### PR TITLE
max call stack (1024) does not result in an exceptional halting

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -872,7 +872,7 @@ Z(\boldsymbol{\sigma}, \boldsymbol{\mu}, I) \equiv
 \end{array}
 \end{equation}
 
-This states that the execution is in an exceptional halting state if there is insufficient gas, if the instruction is invalid (and therefore its $\delta$ subscript is undefined), if there are insufficient stack items, if a {\small JUMP}/{\small JUMPI} destination is invalid or if a {\small CALL}, {\small CALLCODE} or {\small CREATE} instruction is executed when the call stack limit of 1024 is reached. The astute reader will realise that this implies that no instruction can, through its execution, cause an exceptional halt.
+This states that the execution is in an exceptional halting state if there is insufficient gas, if the instruction is invalid (and therefore its $\delta$ subscript is undefined), if there are insufficient stack items or a {\small JUMP}/{\small JUMPI} destination is invalid. The astute reader will realise that this implies that no instruction can, through its execution, cause an exceptional halt.
 
 \subsubsection{Jump Destination Validity}
 


### PR DESCRIPTION
,but instead just returns 0, as handeled in the CALL/CREATE instructions