### PR TITLE
Mem gas calculation

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1551,7 +1551,7 @@ Note the memory cost component, given as the product of $G_{memory}$ and the max
 
 Referencing a zero length range (e.g. by attempting to pass it as the input range to a CALL) does not require memory to be extended to the beginning of the range. $\boldsymbol{\mu}'_i$ is defined as this new maximum number of words of active memory; special-cases are given where these two are not equal.
 
-Note also that $C_{memory}$ is the memory cost function (the expansion function being the difference between the cost before and after). It is a polynomial, with the higher-order coefficient divided and floored, and thus linear up to 32KB of memory used, after which it costs substantially more.
+Note also that $C_{memory}$ is the memory cost function (the expansion function being the difference between the cost before and after). It is a polynomial, with the higher-order coefficient divided and floored, and thus linear up to 724B of memory used, after which it costs substantially more.
 
 While defining the instruction set, we defined the memory-expansion for range function, $M$, thus:
 

--- a/Paper.tex
+++ b/Paper.tex
@@ -1528,7 +1528,7 @@ w \equiv \begin{cases} I_\mathbf{b}[\boldsymbol{\mu}_{pc}] & \text{if} \quad \bo
 
 where:
 \begin{equation}
-C_{memory}(a) \equiv G_{memory}(a + \Big\lfloor \dfrac{a^2}{1024} \Big\rfloor)
+C_{memory}(a) \equiv G_{memory} \cdot a + \Big\lfloor \dfrac{a^2}{512} \Big\rfloor
 \end{equation}
 
 with $C_\text{\tiny CALL}$ and $C_\text{\tiny SSTORE}$ as specified in the appropriate section below. We define the following subsets of instructions:


### PR DESCRIPTION
Old: full_memory_gas_cost = W + floor(W * W / 1024), W = words in memory
New: full_memory_gas_cost = 3 * W + floor(W * W / 512)

So the limit for linear memory cost is now `512^0.5 * 32 = 724`