### PR TITLE
add boundaries to block parameter size due to vm opcodes

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -401,9 +401,9 @@ The component types are defined thus:
 \begin{array}[t]{lclclcl}
 H_p \in \mathbb{B}_{32} & \wedge & H_o \in \mathbb{B}_{32} & \wedge & H_c \in \mathbb{B}_{20} & \wedge \\
 H_r \in \mathbb{B}_{32} & \wedge & H_t \in \mathbb{B}_{32} & \wedge & H_e \in \mathbb{B}_{32} & \wedge \\
-H_b \in \mathbb{B}_{256} & \wedge & H_d \in \mathbb{P} & \wedge & H_i \in \mathbb{P} & \wedge \\
-H_l \in \mathbb{P} & \wedge & H_g \in \mathbb{P} & \wedge & H_s \in \mathbb{P} & \wedge \\
-H_x \in \mathbb{B} & \wedge & H_m \in \mathbb{B}_{32} & \wedge & H_n \in \mathbb{B}_{8}
+H_b \in \mathbb{B}_{256} & \wedge & H_d \in \mathbb{P}_{256} & \wedge & H_i \in \mathbb{P}_{256} & \wedge \\
+H_l \in \mathbb{P}_{256} & \wedge & H_g \in \mathbb{P}_{256} & \wedge & H_s \in \mathbb{P}_{256} & \wedge \\
+H_x \in \mathbb{B}_{\leqslant 1024} & \wedge & H_m \in \mathbb{B}_{32} & \wedge & H_n \in \mathbb{B}_{8}
 \end{array}
 \end{equation}
 


### PR DESCRIPTION
all those values (except of extra data, btw why cant we retrieve extra data in the vm, we should have an opcode for that in Ethereum 1.1.) can be retrieved by vm opcodes, and therefore can not be larger then P_256.
