### PR TITLE
Nitpicking equation (100)

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -745,6 +745,7 @@ We define $\boldsymbol{\sigma}_1$, the first transitional state as the original 
 \begin{equation}
 \boldsymbol{\sigma}_1[r]_b \equiv \boldsymbol{\sigma}[r]_b + v \quad\wedge\quad \boldsymbol{\sigma}_1[s]_b \equiv \boldsymbol{\sigma}[s]_b - v
 \end{equation}
+unless $s = r$.
 
 Throughout the present work, it is assumed that if $\boldsymbol{\sigma}_1[r]$ was originally undefined, it will be created as an account with no code or state and zero balance and nonce. Thus the previous equation should be taken to mean:
 \begin{equation}


### PR DESCRIPTION
Before this commit, equation (100) was not satisfiable when `s` and `r` were equal and `v + v` was not zero.  Though this equation is further complemented in equations (101) through (104), I thought (100) needed a condition `s != r`.
