### PR TITLE
correct secp256k1n off-by-one for homestead blocks

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1438,7 +1438,7 @@ We declare that a signature is invalid unless all the following conditions are t
 0 < r &< \mathtt{\tiny secp256k1n} \\
 0 < s &< \begin{dcases}
 \mathtt{\tiny secp256k1n} & \text{if} \quad H_i < \firsthomesteadblock \\
-\mathtt{\tiny secp256k1n} \div 2 & \text{otherwise} \\
+\mathtt{\tiny secp256k1n} \div 2 + 1 & \text{otherwise} \\
 \end{dcases} \\
  v &\in \{27,28\} 
 \end{align}


### PR DESCRIPTION
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.mediawiki defines, for homestead blocks, that all tx signatures whose s-value is greater than secp256k1n/2 are invalid.

This commit corrects equation 210 which is off-by-one for homestead blocks - most likely a typo from reusing the less-than sign when extending the equation for the two cases. Style-wise, it may look better if `0 < s <` is moved into the conditional, so `≤` can be used for the homestead case.

Parity, geth & ethereumj all implement this condition correctly, so the bug is probably only present in the yellow paper.