### PR TITLE
Add the Travis YML file that builds Paper.pdf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+before_install:
+- sudo apt-get -qq update
+- sudo apt-get install texlive texlive-latex3
+script:
+- pdflatex -interaction=errorstopmode -halt-on-error Paper.tex
+- bibtex Paper
+- pdflatex -interaction=errorstopmode -halt-on-error Paper.tex
+- pdflatex -interaction=errorstopmode -halt-on-error Paper.tex
+- pdflatex -interaction=errorstopmode -halt-on-error Paper.tex


### PR DESCRIPTION
This pull-request adds a Travis configuration file.  Travis builds Paper.pdf.  When the sources contain an error, `pdflatex` does not wait for any input but exits abnormally.