### PR TITLE
Make sure INVALID instruction halts the execution.

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -2019,7 +2019,7 @@ G_{newaccount} & \text{if} \quad \boldsymbol{\sigma}[\boldsymbol{\mu}_\mathbf{s}
 &&&& This means that the recipient is in fact the same account as at present, simply\\
 &&&& that the code is overwritten {\it and} the context is almost entirely identical.\\
 \midrule
-0xfe & {\small INVALID} & 0 & 0 & Designated invalid instruction. \\
+0xfe & {\small INVALID} & $\varnothing$ & $\varnothing$ & Designated invalid instruction. \\
 \midrule
 0xff & {\small SELFDESTRUCT} & 1 & 0 & Halt execution and register account for later deletion. \\
 &&&& $A'_\mathbf{s} \equiv A_\mathbf{s} \cup \{ I_a \}$ \\


### PR DESCRIPTION
Before this pull request, the INVALID instruction did not halt the execution.  The exceptional halting condition (126) detects invalid instrucitons by looking at the value of `\delta`.  Before this pull request, the value of `\delta` for `INVALID` was zero; this did not trigger exceptional halting.  After this pull-request, the value of `\delta` is `\varnothing`, and this triggers exceptional halting.