### PR TITLE
Metroplis: EIP 101 big-modexp precompile

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1414,12 +1414,12 @@ The input and output formats are the same for $\Xi_{\mathtt{SUB}}$, $\Xi_{\matht
 
 \begin{eqnarray}
 \Xi_{\mathtt{ADD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
-\Xi_{\mathtt{ADD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
+\Xi_{\mathtt{ADD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  l_X \\
 g_r &=& G_{addsubbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil \\
 \mathbf{o} &=& \mathtt{\tiny BE}(X + Y) \\
-X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
+X &=& I_\mathbf{d}[32..(31 + l_X)] \\
 l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
-Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
+Y &=& I_\mathbf{d}[(32 + l_X)..(|I_\mathbf{d}| - 1)] \\
 l_Y &=& |I_\mathbf{d}| - 32 - l_X
 \end{eqnarray}
 
@@ -1427,13 +1427,12 @@ The sixth contract performs arbitrary-precision subtraction on non-negative inte
 
 \begin{eqnarray}
 \Xi_{\mathtt{SUB}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
-\Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
-\Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad X < Y \\
+\Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  l_X \, \vee \, X < Y \\
 g_r &=& G_{addsubbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil \\
 \mathbf{o} &=& \mathtt{\tiny BE}(X - Y) \\
-X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
+X &=& I_\mathbf{d}[32..(31 + l_X)] \\
 l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
-Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
+Y &=& I_\mathbf{d}[(32 + l_X)..(|I_\mathbf{d}| - 1)] \\
 l_Y &=& |I_\mathbf{d}| - 32 - l_X
 \end{eqnarray}
 
@@ -1441,12 +1440,12 @@ The seventh contract performs arbitrary-precision multiplication on non-negative
 
 \begin{eqnarray}
 \Xi_{\mathtt{MUL}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
-\Xi_{\mathtt{MUL}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
+\Xi_{\mathtt{MUL}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 < l_X \\
 g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + l_X l_Y / G_{quaddivisor} \\
 \mathbf{o} &=& \mathtt{\tiny BE}(X \times Y) \\
 X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
-l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
-Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
+l_X &=& l_X \in \mathbb{P}_{256} \\
+Y &=& I_\mathbf{d}[(32 + l_X)..(|I_\mathbf{d}| - 1)] \\
 l_Y &=& |I_\mathbf{d}| - 32 - l_X
 \end{eqnarray}
 
@@ -1454,16 +1453,16 @@ The eigth contract performs arbitrary-precision division on non-negative integer
 
 \begin{eqnarray}
 \Xi_{\mathtt{DIV}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
-\Xi_{\mathtt{DIV}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
+\Xi_{\mathtt{DIV}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 < l_X \\
 g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + l_X l_Y / G_{quaddivisor} \\
 \mathbf{o} &=&
 \begin{cases}
  () & \text{if} \  Y = 0 \\
  \mathtt{\tiny BE}\Big(\big\lfloor \dfrac X Y \big\rfloor\Big) & \text{otherwise}
 \end{cases} \\
-X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
+X &=& I_\mathbf{d}[32..(31 + l_X)] \\
 l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
-Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
+Y &=& I_\mathbf{d}[(32 + l_X..(|I_\mathbf{d}| - 1)] \\
 l_Y &=& |I_\mathbf{d}| - 32 - l_X
 \end{eqnarray}
 

--- a/Paper.tex
+++ b/Paper.tex
@@ -1410,7 +1410,8 @@ g_r &=& \Big\lfloor\frac{\max(\ell_M,\ell_B)^2\max(\ell'_E,1)}{G_{quaddivisor}}\
 \ell'_E &=& \begin{cases}
 0 & \text{if}\ \ell_E\le 256\wedge E=0 \\
 \lfloor \log_2(E)\rfloor &\text{if}\ \ell_E\le 256 \wedge E \neq 0 \\
-8(\ell_E - 32) + \lfloor \log_2(i[(96+\ell_B)..(127+\ell_B)]) \rfloor & \text{otherwise} \\
+8(\ell_E - 32) + \lfloor \log_2(i[(96+\ell_B)..(127+\ell_B)]) \rfloor & \text{if}\ 256 < \ell_E \wedge i[(96 + \ell_B)..(127 + \ell_B)]\neq 0 \\
+8(\ell_E - 32) & \text{otherwise} \\
 \end{cases} \\
 \mathbf o &=& (B^E\bmod M)\in\mathbb P_{8\ell_M} \\
 \ell_B &\equiv& i[0..31] \\

--- a/Paper.tex
+++ b/Paper.tex
@@ -1488,7 +1488,7 @@ B &=& I_\mathbf{d}[32..(31 + \ell_B)] \\
 \ell_E &=& I_\mathbf{d}[(32 + \ell_B)..(63 + \ell_B)] \\
 E &=& I_\mathbf{d}[(64 + \ell_B)..(63 + \ell_B + \ell_E)] \\
 M &=& I_\mathbf{d}[(64 + \ell_B + \ell_E)..(|I_\mathbf{d}| - 1)] \\
-\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| < 32 + \ell_B \quad \vee \quad |I_\mathbf{d}| < 64 + \ell_B + \ell_E \\
+\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| < 64 + \ell_B + \ell_E \\
 g_r &=& G_{modexpbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + |M|^2 |E| / G_{quaddivisor} \\
 \mathbf{o} &=&
 \begin{cases}

--- a/Paper.tex
+++ b/Paper.tex
@@ -1408,7 +1408,7 @@ g_r &=& 15 + 3\Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil\\
 
 The fifth contract performs arbitrary-precision addition on non-negative integers.
 The first word in the input specifies the number of bytes that the first non-negative integer $X$ occupies.
-The result is represented in the smallest possible number of bytes.  The first byte in the output is never zero.
+The result is represented in the smallest possible number of bytes.  The first byte in the output, if exists, is never zero.
 
 \begin{eqnarray}
 \Xi_{\mathtt{ADD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\

--- a/Paper.tex
+++ b/Paper.tex
@@ -1414,14 +1414,9 @@ The result is represented in the smallest possible number of bytes.  The first b
 \Xi_{\mathtt{ADD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
 \Xi_{\mathtt{ADD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
 g_r &=& G_{addsubbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil \\
-\mathbf{o} &=& (X + Y) \in \mathbb{B}_\ell \\
+\mathbf{o} &=& \mathtt{\tiny BE}(X + Y) \\
 X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
-Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
-\ell &=&
-\begin{cases}
-0 &\text{if}\, X = Y = 0 \\
-\lfloor \log_8(X + Y) \rfloor + 1 & \text{otherwise}
-\end{cases}
+Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)]
 \end{eqnarray}
 
 The sixth contract performs arbitrary-precision subtraction on non-negative integers.  This is similar to the addition.  The subtraction contract halts exceptionally if the result would be negative.
@@ -1431,14 +1426,9 @@ The sixth contract performs arbitrary-precision subtraction on non-negative inte
 \Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
 \Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad X < Y \\
 g_r &=& G_{addsubbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil \\
-\mathbf{o} &=& (X - Y) \in \mathbb{B}_\ell \\
+\mathbf{o} &=& \mathtt{\tiny BE}(X - Y) \\
 X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
-Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
-\ell &=&
-\begin{cases}
-0 &\text{if}\ X = Y \\
-\lfloor \log_8(X - Y) \rfloor + 1 & \text{otherwise}
-\end{cases}
+Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)]
 \end{eqnarray}
 
 The seventh contract performs arbitrary-precision multiplication on non-negative integers.  The input format is the same as that of the addition contract.
@@ -1447,16 +1437,11 @@ The seventh contract performs arbitrary-precision multiplication on non-negative
 \Xi_{\mathtt{MUL}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
 \Xi_{\mathtt{MUL}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
 g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + \ell_X \ell_Y / G_{quaddivisor} \\
-\mathbf{o} &=& (X \times Y) \in \mathbb{B}_\ell \\
+\mathbf{o} &=& \mathtt{\tiny BE}(X \times Y) \\
 X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
 \ell_X &=& I_\mathbf{d}[0..31] \\
 Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
-\ell_Y &=& |I_\mathbf{d}| - 32 - \ell_X \\
-\ell &=&
-\begin{cases}
-0 &\text{if}\ X = 0 \ \vee\  Y = 0 \\
-\lfloor \log_8(X \times Y) \rfloor + 1 & \text{otherwise}
-\end{cases}
+\ell_Y &=& |I_\mathbf{d}| - 32 - \ell_X
 \end{eqnarray}
 
 The eigth contract performs arbitrary-precision division on non-negative integers.  The definition is similar to that of the multiplication contract.
@@ -1468,17 +1453,12 @@ g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Bi
 \mathbf{o} &=&
 \begin{cases}
  () & \text{if} \  Y = 0 \\
- \Big\lfloor \dfrac X Y \Big\rfloor \in \mathbb{B}_\ell & \text{otherwise}
+ \mathtt{\tiny BE}\Big(\big\lfloor \dfrac X Y \big\rfloor\Big) & \text{otherwise}
 \end{cases} \\
 X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
 \ell_X &=& I_\mathbf{d}[0..31] \\
 Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
-\ell_Y &=& |I_\mathbf{d}| - 32 - \ell_X \\
-\ell &=&
-\begin{cases}
-0 &\text{if}\ Y = 0 \ \vee \ \Big\lfloor \dfrac X Y \Big\rfloor = 0 \\
-\lfloor \log_8(\Big\lfloor \dfrac X Y \Big\rfloor) \rfloor + 1 & \text{otherwise}
-\end{cases}
+\ell_Y &=& |I_\mathbf{d}| - 32 - \ell_X
 \end{eqnarray}
 
 The ninth contract performs arbitrary-precision exponentiation under modulo.  Here, $0 ^ 0$ is taken to be one.
@@ -1494,12 +1474,7 @@ g_r &=& G_{modexpbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Bi
 \mathbf{o} &=&
 \begin{cases}
  () & \text{if} \  M = 0 \\
- B ^ E \bmod M \in \mathbb{B}_\ell & \text{otherwise}
-\end{cases} \\
-\ell &=&
-\begin{cases}
-0 &\text{if}\ M = 0 \quad \vee \quad {B ^ E} \bmod M = 0 \\
-\lfloor \log_8(B ^ E \bmod M) \rfloor + 1 & \text{otherwise}
+ \mathtt{\tiny BE}(B ^ E \bmod M) & \text{otherwise}
 \end{cases}
 \end{eqnarray}
 

--- a/Paper.tex
+++ b/Paper.tex
@@ -774,11 +774,7 @@ The account's associated code (identified as the fragment whose Keccak hash is $
 \Xi_{\mathtt{SHA256}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 2 \\
 \Xi_{\mathtt{RIP160}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 3 \\
 \Xi_{\mathtt{ID}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 4 \\
-\Xi_{\mathtt{ADD}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 5 \\
-\Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 6 \\
-\Xi_{\mathtt{MUL}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 7 \\
-\Xi_{\mathtt{DIV}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 8 \\
-\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 9 \\
+\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 5 \\
 \Xi(\boldsymbol{\sigma}_1, g, I) & \text{otherwise} \end{cases} \\
 I_a & \equiv & r \\
 I_o & \equiv & o \\
@@ -1406,67 +1402,7 @@ g_r &=& 15 + 3\Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil\\
 \mathbf{o} &=& I_\mathbf{d}
 \end{eqnarray}
 
-The fifth contract performs arbitrary-precision addition on non-negative integers.
-The first word in the input specifies the number of bytes that the first non-negative integer $X$ occupies.  The rest of the input is interpreted as $Y$.
-Both $X$ and $Y$ are interpreted as a natural number encoded as byte sequences in the big-endian way.
-The result is represented in the smallest possible number of bytes.  The first byte in the output, if exists, is never zero.
-The input and output formats are the same for $\Xi_{\mathtt{SUB}}$, $\Xi_{\mathtt{MUL}}$ and $\Xi_{\mathtt{DIV}}$ as well.
-
-\begin{eqnarray}
-\Xi_{\mathtt{ADD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
-\Xi_{\mathtt{ADD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  l_X \\
-g_r &=& G_{addsubbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil \\
-\mathbf{o} &=& \mathtt{\tiny BE}(X + Y) \\
-X &=& I_\mathbf{d}[32..(31 + l_X)] \\
-l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
-Y &=& I_\mathbf{d}[(32 + l_X)..(|I_\mathbf{d}| - 1)] \\
-l_Y &=& |I_\mathbf{d}| - 32 - l_X
-\end{eqnarray}
-
-The sixth contract performs arbitrary-precision subtraction on non-negative integers.  This is similar to the addition.  The subtraction contract halts exceptionally if the result would be negative.
-
-\begin{eqnarray}
-\Xi_{\mathtt{SUB}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
-\Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  l_X \, \vee \, X < Y \\
-g_r &=& G_{addsubbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil \\
-\mathbf{o} &=& \mathtt{\tiny BE}(X - Y) \\
-X &=& I_\mathbf{d}[32..(31 + l_X)] \\
-l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
-Y &=& I_\mathbf{d}[(32 + l_X)..(|I_\mathbf{d}| - 1)] \\
-l_Y &=& |I_\mathbf{d}| - 32 - l_X
-\end{eqnarray}
-
-The seventh contract performs arbitrary-precision multiplication on non-negative integers.  The input format is the same as that of the addition contract.
-
-\begin{eqnarray}
-\Xi_{\mathtt{MUL}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
-\Xi_{\mathtt{MUL}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 < l_X \\
-g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + l_X l_Y / G_{quaddivisor} \\
-\mathbf{o} &=& \mathtt{\tiny BE}(X \times Y) \\
-X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
-l_X &=& l_X \in \mathbb{P}_{256} \\
-Y &=& I_\mathbf{d}[(32 + l_X)..(|I_\mathbf{d}| - 1)] \\
-l_Y &=& |I_\mathbf{d}| - 32 - l_X
-\end{eqnarray}
-
-The eigth contract performs arbitrary-precision division on non-negative integers.  The definition is similar to that of the multiplication contract.
-
-\begin{eqnarray}
-\Xi_{\mathtt{DIV}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
-\Xi_{\mathtt{DIV}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 < l_X \\
-g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + l_X l_Y / G_{quaddivisor} \\
-\mathbf{o} &=&
-\begin{cases}
- () & \text{if} \  Y = 0 \\
- \mathtt{\tiny BE}\Big(\big\lfloor \dfrac X Y \big\rfloor\Big) & \text{otherwise}
-\end{cases} \\
-X &=& I_\mathbf{d}[32..(31 + l_X)] \\
-l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
-Y &=& I_\mathbf{d}[(32 + l_X..(|I_\mathbf{d}| - 1)] \\
-l_Y &=& |I_\mathbf{d}| - 32 - l_X
-\end{eqnarray}
-
-The ninth contract performs arbitrary-precision exponentiation under modulo.  Here, $0 ^ 0$ is taken to be one.
+The fifth contract performs arbitrary-precision exponentiation under modulo.  Here, $0 ^ 0$ is taken to be one.
 The first word in the input specifies the number of bytes that the first non-negative integer $B$ occupies.
 The second word in the input specifies the number of bytes that the second non-negative integer $E$ occupies.
 These two words are followed by $B$ and $E$; and the rest of the input is interpreted as the third non-negative integer $M$.

--- a/Paper.tex
+++ b/Paper.tex
@@ -1402,26 +1402,21 @@ g_r &=& 15 + 3\Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil\\
 \mathbf{o} &=& I_\mathbf{d}
 \end{eqnarray}
 
-The fifth contract performs arbitrary-precision exponentiation under modulo.  Here, $0 ^ 0$ is taken to be one.
-The first word in the input specifies the number of bytes that the first non-negative integer $B$ occupies.
-The second word in the input specifies the number of bytes that the second non-negative integer $E$ occupies.
-These two words are followed by $B$ and $E$; and the rest of the input is interpreted as the third non-negative integer $M$.
-All non-negative integers $B$, $E$ $M$ are encoded as byte sequences in the big-endian way.
-The output format is the same as the precompiled contract $\Xi_{\mathtt{ADD}}$.
+The fifth contract performs arbitrary-precision exponentiation under modulo.  Here, $0 ^ 0$ is taken to be one, and $x \bmod 0$ is ???. The first word in the input specifies the number of bytes that the first non-negative integer $B$ occupies. The second word in the input specifies the number of bytes that the second non-negative integer $E$ occupies. The third word in the input specifies the number of bytes that the third non-negative integer $M$ occupies.  These three words are followed by $B$, $E$ and $M$.  The rest of the input is discarded.  Whenever the input is too short, the missing bytes are considered to be zero.  The output is encoded big-endian into the same format as $M$'s.
 
 \begin{eqnarray}
-\Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
-l_B &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
-l_E &=& I_\mathbf{d}[32..63] \in \mathbb{P}_{256} \\
-B &=& I_\mathbf{d}[64..(63 + l_B)] \\
-E &=& I_\mathbf{d}[(64 + l_B)..(63 + l_B + l_E)] \\
-M &=& I_\mathbf{d}[(64 + l_B + l_E)..(|I_\mathbf{d}| - 1)] \\
-\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| < 64 + l_B + l_E\,\vee\,M\le B \\
-g_r &=& G_{modexpbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + |M|^2 |E| / G_{quaddivisor} \\
-\mathbf{o} &=&
-\begin{cases}
- () & \text{if} \  M = 0 \\
- \mathtt{\tiny BE}(B ^ E \bmod M) & \text{otherwise}
+\Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:} \\
+g_r &=& \Big\lfloor\frac{\max(\ell_M,\ell_B)^2\max(\ell_E,1)}{G_{quaddivisor}}\Big\rfloor \\
+\mathbf o &=& (B^E\bmod M)\in\mathbb P_{8\ell_M} \\
+\ell_B &\equiv& i[0..31] \\
+\ell_E &\equiv& i[32..63] \\
+\ell_M &\equiv& i[64..95] \\
+B &\equiv& i[96..(95+\ell_B)] \\
+E &\equiv& i[(96+\ell_B)..(95+\ell_B+\ell_E)] \\
+M &\equiv& i[(96+\ell_B+\ell_E)..(95+\ell_B+\ell_E+\ell_M)] \\
+i[x] &\equiv& \begin{cases}
+I_{\mathbf d}[x] &\text{if}\ x < |I_{\mathbf d}| \\
+0 &\text{otherwise}
 \end{cases}
 \end{eqnarray}
 
@@ -1530,11 +1525,7 @@ $G_{sha3}$ & 30 & Paid for each {\small SHA3} operation. \\
 $G_{sha3word}$ & 6 & Paid for each word (rounded up) for input data to a {\small SHA3} operation. \\
 $G_{copy}$ & 3 & Partial payment for {\small *COPY} operations, multiplied by words copied, rounded up. \\
 $G_{blockhash}$ & 20 & Payment for {\small BLOCKHASH} operation. \\
-$G_{addsubbase}$ & 15 & Payment for the precompiled addition or subtraction contract. \\
-$G_{muldivbase}$ & 30 & Payment for the precompiled multiplication or division contract. \\
-$G_{modexpbase}$ & 45 & Payment for the precompiled exponention under modulo. \\
-$G_{arithword}$ & 6 & Paid for each word used in precompiled contracts for arbitrary precision arighmetics.\\
-$G_{quaddivisor}$ & 32 & The quadratic coefficient of the input sizes of multiplication and division precompiled contracts.  \\
+$G_{quaddivisor}$ & 20 & The quadratic coefficient of the input sizes of the exponation-over-modulo precompiled contract.  \\
 
 %extern u256 const c_copyGas;			///< Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
 \bottomrule

--- a/Paper.tex
+++ b/Paper.tex
@@ -1406,7 +1406,12 @@ The fifth contract performs arbitrary-precision exponentiation under modulo. Her
 
 \begin{eqnarray}
 \Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:} \\
-g_r &=& \Big\lfloor\frac{\max(\ell_M,\ell_B)^2\max(\ell'_E,1)}{G_{quaddivisor}}\Big\rfloor \\
+g_r &=& \Big\lfloor\frac{f\big(\max(\ell_M,\ell_B)\big)\max(\ell'_E,1)}{G_{quaddivisor}}\Big\rfloor \\
+f(x) &\equiv& \begin{cases}
+x^2 & \text{if}\ x \le 64 \\
+\Big\lfloor\dfrac{x^2}{4}\Big\rfloor + 96 x - 3072 & \text{if}\ 64 < x \le 1024 \\
+\Big\lfloor\dfrac{x^2}{16}\Big\rfloor + 480x - 199680 & \text{otherwise}
+\end{cases}\\
 \ell'_E &=& \begin{cases}
 0 & \text{if}\ \ell_E\le 32\wedge E=0 \\
 \lfloor \log_2(E)\rfloor &\text{if}\ \ell_E\le 32 \wedge E \neq 0 \\

--- a/Paper.tex
+++ b/Paper.tex
@@ -1481,6 +1481,7 @@ Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
 \end{cases}
 \end{eqnarray}
 
+The ninth contract performs arbitrary-precision exponentiation under modulo.  Here, $0 ^ 0$ is taken to be one.
 \begin{eqnarray}
 \Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
 \ell_B &=& I_\mathbf{d}[0..31] \\
@@ -1716,7 +1717,7 @@ Here given are the various exceptions to the state transition rules given in sec
 \begin{tabular*}{\columnwidth}[h]{rlrrl}
 \toprule
 \multicolumn{5}{c}{\textbf{0s: Stop and Arithmetic Operations}} \\
-\multicolumn{5}{l}{All arithmetic is modulo $2^{256}$ unless otherwise noted.  $0 ^ 0$ is defined to be $1$.} \vspace{5pt} \\
+\multicolumn{5}{l}{All arithmetic is modulo $2^{256}$ unless otherwise noted.} \vspace{5pt} \\
 \textbf{Value} & \textbf{Mnemonic} & $\delta$ & $\alpha$ & \textbf{Description} \vspace{5pt} \\
 0x00 & {\small STOP} & 0 & 0 & Halts execution. \\
 \midrule

--- a/Paper.tex
+++ b/Paper.tex
@@ -1406,7 +1406,12 @@ The fifth contract performs arbitrary-precision exponentiation under modulo. Her
 
 \begin{eqnarray}
 \Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:} \\
-g_r &=& \Big\lfloor\frac{\max(\ell_M,\ell_B)^2\max(\ell_E,1)}{G_{quaddivisor}}\Big\rfloor \\
+g_r &=& \Big\lfloor\frac{\max(\ell_M,\ell_B)^2\max(\ell'_E,1)}{G_{quaddivisor}}\Big\rfloor \\
+\ell'_E &=& \begin{cases}
+0 & \text{if}\ \ell_E\le 256\wedge E=0 \\
+\lfloor \log_2(E)\rfloor &\text{if}\ \ell_E\le 256 \wedge E \neq 0 \\
+8(\ell_E - 32) + \lfloor \log_2(i[(96+\ell_B)..(127+\ell_B)]) \rfloor & \text{otherwise} \\
+\end{cases} \\
 \mathbf o &=& (B^E\bmod M)\in\mathbb P_{8\ell_M} \\
 \ell_B &\equiv& i[0..31] \\
 \ell_E &\equiv& i[32..63] \\
@@ -1525,7 +1530,7 @@ $G_{sha3}$ & 30 & Paid for each {\small SHA3} operation. \\
 $G_{sha3word}$ & 6 & Paid for each word (rounded up) for input data to a {\small SHA3} operation. \\
 $G_{copy}$ & 3 & Partial payment for {\small *COPY} operations, multiplied by words copied, rounded up. \\
 $G_{blockhash}$ & 20 & Payment for {\small BLOCKHASH} operation. \\
-$G_{quaddivisor}$ & 20 & The quadratic coefficient of the input sizes of the exponation-over-modulo precompiled contract. \\
+$G_{quaddivisor}$ & 100 & The quadratic coefficient of the input sizes of the exponation-over-modulo precompiled contract. \\
 
 %extern u256 const c_copyGas;			///< Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
 \bottomrule

--- a/Paper.tex
+++ b/Paper.tex
@@ -777,6 +777,7 @@ The account's associated code (identified as the fragment whose Keccak hash is $
 \Xi_{\mathtt{ADD}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 5 \\
 \Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 6 \\
 \Xi_{\mathtt{MUL}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 7 \\
+\Xi_{\mathtt{DIV}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 8 \\
 \Xi(\boldsymbol{\sigma}_1, g, I) & \text{otherwise} \end{cases} \\
 I_a & \equiv & r \\
 I_o & \equiv & o \\
@@ -1439,7 +1440,7 @@ Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
 \end{cases}
 \end{eqnarray}
 
-The seventh contract performs arbitrary-precision multiplication on non-negative integers.  The definition is similar to that of the addition contract.
+The seventh contract performs arbitrary-precision multiplication on non-negative integers.  The input format is the same as that of the addition contract.
 
 \begin{eqnarray}
 \Xi_{\mathtt{MUL}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
@@ -1454,6 +1455,28 @@ Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
 \begin{cases}
 0 &\text{if}\ X = 0 \ \text{or}\  Y = 0 \\
 \lfloor \log_8(X \times Y) \rfloor + 1 & \text{otherwise}
+\end{cases}
+\end{eqnarray}
+
+The eigth contract performs arbitrary-precision division on non-negative integers.  The definition is similar to that of the multiplication contract.
+
+\begin{eqnarray}
+\Xi_{\mathtt{DIV}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
+\Xi_{\mathtt{DIV}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
+g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + \ell_X \ell_Y / G_{quaddivisor} \\
+\mathbf{o} &=&
+\begin{cases}
+ () & \text{if} \  Y = 0 \\
+ \Big\lfloor \dfrac X Y \Big\rfloor \in \mathbb{B}_\ell & \text{otherwise}
+\end{cases} \\
+X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
+\ell_X &=& I_\mathbf{d}[0..31] \\
+Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
+\ell_Y &=& |I_\mathbf{d}| - 32 - \ell_X \\
+\ell &=&
+\begin{cases}
+0 &\text{if}\ Y = 0 \ \text{or} \ \Big\lfloor \dfrac X Y \Big\rfloor = 0 \\
+\lfloor \log_8(\Big\lfloor \dfrac X Y \Big\rfloor) \rfloor + 1 & \text{otherwise}
 \end{cases}
 \end{eqnarray}
 

--- a/Paper.tex
+++ b/Paper.tex
@@ -1408,9 +1408,9 @@ The fifth contract performs arbitrary-precision exponentiation under modulo. Her
 \Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:} \\
 g_r &=& \Big\lfloor\frac{\max(\ell_M,\ell_B)^2\max(\ell'_E,1)}{G_{quaddivisor}}\Big\rfloor \\
 \ell'_E &=& \begin{cases}
-0 & \text{if}\ \ell_E\le 256\wedge E=0 \\
-\lfloor \log_2(E)\rfloor &\text{if}\ \ell_E\le 256 \wedge E \neq 0 \\
-8(\ell_E - 32) + \lfloor \log_2(i[(96+\ell_B)..(127+\ell_B)]) \rfloor & \text{if}\ 256 < \ell_E \wedge i[(96 + \ell_B)..(127 + \ell_B)]\neq 0 \\
+0 & \text{if}\ \ell_E\le 32\wedge E=0 \\
+\lfloor \log_2(E)\rfloor &\text{if}\ \ell_E\le 32 \wedge E \neq 0 \\
+8(\ell_E - 32) + \lfloor \log_2(i[(96+\ell_B)..(127+\ell_B)]) \rfloor & \text{if}\ 32 < \ell_E \wedge i[(96 + \ell_B)..(127 + \ell_B)]\neq 0 \\
 8(\ell_E - 32) & \text{otherwise} \\
 \end{cases} \\
 \mathbf o &=& (B^E\bmod M)\in\mathbb P_{8\ell_M} \\

--- a/Paper.tex
+++ b/Paper.tex
@@ -774,6 +774,7 @@ The account's associated code (identified as the fragment whose Keccak hash is $
 \Xi_{\mathtt{SHA256}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 2 \\
 \Xi_{\mathtt{RIP160}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 3 \\
 \Xi_{\mathtt{ID}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 4 \\
+\Xi_{\mathtt{ADD}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 5 \\
 \Xi(\boldsymbol{\sigma}_1, g, I) & \text{otherwise} \end{cases} \\
 I_a & \equiv & r \\
 I_o & \equiv & o \\
@@ -1394,13 +1395,30 @@ For the purposes here, we assume we have well-defined standard cryptographic fun
 \mathtt{\small RIPEMD160}(\mathbf{i} \in \mathbb{B}) & \equiv & o \in \mathbb{B}_{20}
 \end{eqnarray}
 
-Finally, the fourth contract, the identity function $\Xi_{\mathtt{ID}}$ simply defines the output as the input:
+The fourth contract, the identity function $\Xi_{\mathtt{ID}}$ simply defines the output as the input:
 \begin{eqnarray}
 \Xi_{\mathtt{ID}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{where:} \\
 g_r &=& 15 + 3\Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil\\
 \mathbf{o} &=& I_\mathbf{d}
 \end{eqnarray}
 
+The fifth contract performs arbitrary-precision addition on non-negative integers.
+The first word in the input specifies the number of bytes that the first non-negative integer $X$ occupies.
+The result is represented in the smallest possible number of bytes.  The first byte in the output is never zero.
+
+\begin{eqnarray}
+\Xi_{\mathtt{ADD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
+\Xi_{\mathtt{ADD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
+g_r &=& G_{addsubbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil \\
+\mathbf{o} &=& (X + Y) \in \mathbb{B}_\ell \\
+X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
+Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
+\ell &=&
+\begin{cases}
+0 &\text{if}\, X = Y = 0 \\
+\lfloor \log_8(X + Y) \rfloor + 1 & \text{otherwise}
+\end{cases}
+\end{eqnarray}
 
 \section{Signing Transactions}\label{app:signing}
 
@@ -1507,6 +1525,8 @@ $G_{sha3}$ & 30 & Paid for each {\small SHA3} operation. \\
 $G_{sha3word}$ & 6 & Paid for each word (rounded up) for input data to a {\small SHA3} operation. \\
 $G_{copy}$ & 3 & Partial payment for {\small *COPY} operations, multiplied by words copied, rounded up. \\
 $G_{blockhash}$ & 20 & Payment for {\small BLOCKHASH} operation. \\
+$G_{addsubbase}$ & 15 & Payment for the precompiled addition or subtraction contract \\
+$G_{arithword}$ & 6 & Paid for each word used in precompiled contracts for arbitrary precision arighmetics.\\
 
 %extern u256 const c_copyGas;			///< Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
 \bottomrule

--- a/Paper.tex
+++ b/Paper.tex
@@ -775,6 +775,8 @@ The account's associated code (identified as the fragment whose Keccak hash is $
 \Xi_{\mathtt{RIP160}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 3 \\
 \Xi_{\mathtt{ID}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 4 \\
 \Xi_{\mathtt{ADD}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 5 \\
+\Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 6 \\
+\Xi_{\mathtt{MUL}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 7 \\
 \Xi(\boldsymbol{\sigma}_1, g, I) & \text{otherwise} \end{cases} \\
 I_a & \equiv & r \\
 I_o & \equiv & o \\
@@ -1420,6 +1422,41 @@ Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
 \end{cases}
 \end{eqnarray}
 
+The sixth contract performs arbitrary-precision subtraction on non-negative integers.  This is similar to the addition.  The subtraction contract halts exceptionally if the result would be negative.
+
+\begin{eqnarray}
+\Xi_{\mathtt{SUB}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
+\Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
+\Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad X < Y \\
+g_r &=& G_{addsubbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil \\
+\mathbf{o} &=& (X - Y) \in \mathbb{B}_\ell \\
+X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
+Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
+\ell &=&
+\begin{cases}
+0 &\text{if}\ X = Y \\
+\lfloor \log_8(X - Y) \rfloor + 1 & \text{otherwise}
+\end{cases}
+\end{eqnarray}
+
+The seventh contract performs arbitrary-precision multiplication on non-negative integers.  The definition is similar to that of the addition contract.
+
+\begin{eqnarray}
+\Xi_{\mathtt{MUL}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
+\Xi_{\mathtt{MUL}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
+g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + \ell_X \ell_Y / G_{quaddivisor} \\
+\mathbf{o} &=& (X \times Y) \in \mathbb{B}_\ell \\
+X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
+\ell_X &=& I_\mathbf{d}[0..31] \\
+Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
+\ell_Y &=& |I_\mathbf{d}| - 32 - \ell_X \\
+\ell &=&
+\begin{cases}
+0 &\text{if}\ X = 0 \ \text{or}\  Y = 0 \\
+\lfloor \log_8(X \times Y) \rfloor + 1 & \text{otherwise}
+\end{cases}
+\end{eqnarray}
+
 \section{Signing Transactions}\label{app:signing}
 
 The method of signing transactions is similar to the `Electrum style signatures'; it utilises the SECP-256k1 curve as described by \cite{gura2004comparing}.
@@ -1526,7 +1563,9 @@ $G_{sha3word}$ & 6 & Paid for each word (rounded up) for input data to a {\small
 $G_{copy}$ & 3 & Partial payment for {\small *COPY} operations, multiplied by words copied, rounded up. \\
 $G_{blockhash}$ & 20 & Payment for {\small BLOCKHASH} operation. \\
 $G_{addsubbase}$ & 15 & Payment for the precompiled addition or subtraction contract \\
+$G_{muldivbase}$ & 30 & Payment for the precompiled multiplication or division contract \\
 $G_{arithword}$ & 6 & Paid for each word used in precompiled contracts for arbitrary precision arighmetics.\\
+$G_{quaddivisor}$ & 32 & The quadratic coefficient of the input sizes of multiplication and division precompiled contracts.  \\
 
 %extern u256 const c_copyGas;			///< Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
 \bottomrule

--- a/Paper.tex
+++ b/Paper.tex
@@ -1454,7 +1454,7 @@ Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
 \ell_Y &=& |I_\mathbf{d}| - 32 - \ell_X \\
 \ell &=&
 \begin{cases}
-0 &\text{if}\ X = 0 \ \text{or}\  Y = 0 \\
+0 &\text{if}\ X = 0 \ \vee\  Y = 0 \\
 \lfloor \log_8(X \times Y) \rfloor + 1 & \text{otherwise}
 \end{cases}
 \end{eqnarray}
@@ -1476,7 +1476,7 @@ Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
 \ell_Y &=& |I_\mathbf{d}| - 32 - \ell_X \\
 \ell &=&
 \begin{cases}
-0 &\text{if}\ Y = 0 \ \text{or} \ \Big\lfloor \dfrac X Y \Big\rfloor = 0 \\
+0 &\text{if}\ Y = 0 \ \vee \ \Big\lfloor \dfrac X Y \Big\rfloor = 0 \\
 \lfloor \log_8(\Big\lfloor \dfrac X Y \Big\rfloor) \rfloor + 1 & \text{otherwise}
 \end{cases}
 \end{eqnarray}
@@ -1493,12 +1493,12 @@ g_r &=& G_{modexpbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Bi
 \mathbf{o} &=&
 \begin{cases}
  () & \text{if} \  M = 0 \\
- B ^ E \mod M \in \mathbb{B}_\ell & \text{otherwise}
+ B ^ E \bmod M \in \mathbb{B}_\ell & \text{otherwise}
 \end{cases} \\
 \ell &=&
 \begin{cases}
-0 &\text{if}\ M = 0 \ \text{or} \ B ^ E \mod M = 0 \\
-\lfloor \log_8(B ^ E \mod M) \rfloor + 1 & \text{otherwise}
+0 &\text{if}\ M = 0 \quad \vee \quad {B ^ E} \bmod M = 0 \\
+\lfloor \log_8(B ^ E \bmod M) \rfloor + 1 & \text{otherwise}
 \end{cases}
 \end{eqnarray}
 
@@ -1607,8 +1607,9 @@ $G_{sha3}$ & 30 & Paid for each {\small SHA3} operation. \\
 $G_{sha3word}$ & 6 & Paid for each word (rounded up) for input data to a {\small SHA3} operation. \\
 $G_{copy}$ & 3 & Partial payment for {\small *COPY} operations, multiplied by words copied, rounded up. \\
 $G_{blockhash}$ & 20 & Payment for {\small BLOCKHASH} operation. \\
-$G_{addsubbase}$ & 15 & Payment for the precompiled addition or subtraction contract \\
-$G_{muldivbase}$ & 30 & Payment for the precompiled multiplication or division contract \\
+$G_{addsubbase}$ & 15 & Payment for the precompiled addition or subtraction contract. \\
+$G_{muldivbase}$ & 30 & Payment for the precompiled multiplication or division contract. \\
+$G_{modexpbase}$ & 45 & Payment for the precompiled exponention under modulo. \\
 $G_{arithword}$ & 6 & Paid for each word used in precompiled contracts for arbitrary precision arighmetics.\\
 $G_{quaddivisor}$ & 32 & The quadratic coefficient of the input sizes of multiplication and division precompiled contracts.  \\
 

--- a/Paper.tex
+++ b/Paper.tex
@@ -1402,7 +1402,7 @@ g_r &=& 15 + 3\Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil\\
 \mathbf{o} &=& I_\mathbf{d}
 \end{eqnarray}
 
-The fifth contract performs arbitrary-precision exponentiation under modulo.  Here, $0 ^ 0$ is taken to be one, and $x \bmod 0$ is zero for all $x$. The first word in the input specifies the number of bytes that the first non-negative integer $B$ occupies. The second word in the input specifies the number of bytes that the second non-negative integer $E$ occupies. The third word in the input specifies the number of bytes that the third non-negative integer $M$ occupies.  These three words are followed by $B$, $E$ and $M$.  The rest of the input is discarded.  Whenever the input is too short, the missing bytes are considered to be zero.  The output is encoded big-endian into the same format as $M$'s.
+The fifth contract performs arbitrary-precision exponentiation under modulo. Here, $0 ^ 0$ is taken to be one, and $x \bmod 0$ is zero for all $x$. The first word in the input specifies the number of bytes that the first non-negative integer $B$ occupies. The second word in the input specifies the number of bytes that the second non-negative integer $E$ occupies. The third word in the input specifies the number of bytes that the third non-negative integer $M$ occupies. These three words are followed by $B$, $E$ and $M$. The rest of the input is discarded. Whenever the input is too short, the missing bytes are considered to be zero. The output is encoded big-endian into the same format as $M$'s.
 
 \begin{eqnarray}
 \Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:} \\
@@ -1525,7 +1525,7 @@ $G_{sha3}$ & 30 & Paid for each {\small SHA3} operation. \\
 $G_{sha3word}$ & 6 & Paid for each word (rounded up) for input data to a {\small SHA3} operation. \\
 $G_{copy}$ & 3 & Partial payment for {\small *COPY} operations, multiplied by words copied, rounded up. \\
 $G_{blockhash}$ & 20 & Payment for {\small BLOCKHASH} operation. \\
-$G_{quaddivisor}$ & 20 & The quadratic coefficient of the input sizes of the exponation-over-modulo precompiled contract.  \\
+$G_{quaddivisor}$ & 20 & The quadratic coefficient of the input sizes of the exponation-over-modulo precompiled contract. \\
 
 %extern u256 const c_copyGas;			///< Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
 \bottomrule

--- a/Paper.tex
+++ b/Paper.tex
@@ -1402,7 +1402,7 @@ g_r &=& 15 + 3\Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil\\
 \mathbf{o} &=& I_\mathbf{d}
 \end{eqnarray}
 
-The fifth contract performs arbitrary-precision exponentiation under modulo.  Here, $0 ^ 0$ is taken to be one, and $x \bmod 0$ is ???. The first word in the input specifies the number of bytes that the first non-negative integer $B$ occupies. The second word in the input specifies the number of bytes that the second non-negative integer $E$ occupies. The third word in the input specifies the number of bytes that the third non-negative integer $M$ occupies.  These three words are followed by $B$, $E$ and $M$.  The rest of the input is discarded.  Whenever the input is too short, the missing bytes are considered to be zero.  The output is encoded big-endian into the same format as $M$'s.
+The fifth contract performs arbitrary-precision exponentiation under modulo.  Here, $0 ^ 0$ is taken to be one, and $x \bmod 0$ is zero for all $x$. The first word in the input specifies the number of bytes that the first non-negative integer $B$ occupies. The second word in the input specifies the number of bytes that the second non-negative integer $E$ occupies. The third word in the input specifies the number of bytes that the third non-negative integer $M$ occupies.  These three words are followed by $B$, $E$ and $M$.  The rest of the input is discarded.  Whenever the input is too short, the missing bytes are considered to be zero.  The output is encoded big-endian into the same format as $M$'s.
 
 \begin{eqnarray}
 \Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:} \\

--- a/Paper.tex
+++ b/Paper.tex
@@ -778,6 +778,7 @@ The account's associated code (identified as the fragment whose Keccak hash is $
 \Xi_{\mathtt{SUB}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 6 \\
 \Xi_{\mathtt{MUL}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 7 \\
 \Xi_{\mathtt{DIV}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 8 \\
+\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}_1, g, I) & \text{if} \quad r = 9 \\
 \Xi(\boldsymbol{\sigma}_1, g, I) & \text{otherwise} \end{cases} \\
 I_a & \equiv & r \\
 I_o & \equiv & o \\
@@ -1480,6 +1481,27 @@ Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
 \end{cases}
 \end{eqnarray}
 
+\begin{eqnarray}
+\Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
+\ell_B &=& I_\mathbf{d}[0..31] \\
+B &=& I_\mathbf{d}[32..(31 + \ell_B)] \\
+\ell_E &=& I_\mathbf{d}[(32 + \ell_B)..(63 + \ell_B)] \\
+E &=& I_\mathbf{d}[(64 + \ell_B)..(63 + \ell_B + \ell_E)] \\
+M &=& I_\mathbf{d}[(64 + \ell_B + \ell_E)..(|I_\mathbf{d}| - 1)] \\
+\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| < 32 + \ell_B \quad \vee \quad |I_\mathbf{d}| < 64 + \ell_B + \ell_E \\
+g_r &=& G_{modexpbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + |M|^2 |E| / G_{quaddivisor} \\
+\mathbf{o} &=&
+\begin{cases}
+ () & \text{if} \  M = 0 \\
+ B ^ E \mod M \in \mathbb{B}_\ell & \text{otherwise}
+\end{cases} \\
+\ell &=&
+\begin{cases}
+0 &\text{if}\ M = 0 \ \text{or} \ B ^ E \mod M = 0 \\
+\lfloor \log_8(B ^ E \mod M) \rfloor + 1 & \text{otherwise}
+\end{cases}
+\end{eqnarray}
+
 \section{Signing Transactions}\label{app:signing}
 
 The method of signing transactions is similar to the `Electrum style signatures'; it utilises the SECP-256k1 curve as described by \cite{gura2004comparing}.
@@ -1693,7 +1715,7 @@ Here given are the various exceptions to the state transition rules given in sec
 \begin{tabular*}{\columnwidth}[h]{rlrrl}
 \toprule
 \multicolumn{5}{c}{\textbf{0s: Stop and Arithmetic Operations}} \\
-\multicolumn{5}{l}{All arithmetic is modulo $2^{256}$ unless otherwise noted.} \vspace{5pt} \\
+\multicolumn{5}{l}{All arithmetic is modulo $2^{256}$ unless otherwise noted.  $0 ^ 0$ is defined to be $1$.} \vspace{5pt} \\
 \textbf{Value} & \textbf{Mnemonic} & $\delta$ & $\alpha$ & \textbf{Description} \vspace{5pt} \\
 0x00 & {\small STOP} & 0 & 0 & Halts execution. \\
 \midrule

--- a/Paper.tex
+++ b/Paper.tex
@@ -1485,8 +1485,8 @@ The ninth contract performs arbitrary-precision exponentiation under modulo.  He
 \begin{eqnarray}
 \Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
 \ell_B &=& I_\mathbf{d}[0..31] \\
-B &=& I_\mathbf{d}[32..(31 + \ell_B)] \\
-\ell_E &=& I_\mathbf{d}[(32 + \ell_B)..(63 + \ell_B)] \\
+\ell_E &=& I_\mathbf{d}[32..63] \\
+B &=& I_\mathbf{d}[64..(63 + \ell_B)] \\
 E &=& I_\mathbf{d}[(64 + \ell_B)..(63 + \ell_B + \ell_E)] \\
 M &=& I_\mathbf{d}[(64 + \ell_B + \ell_E)..(|I_\mathbf{d}| - 1)] \\
 \Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| < 64 + \ell_B + \ell_E \\

--- a/Paper.tex
+++ b/Paper.tex
@@ -1480,7 +1480,7 @@ l_E &=& I_\mathbf{d}[32..63] \in \mathbb{P}_{256} \\
 B &=& I_\mathbf{d}[64..(63 + l_B)] \\
 E &=& I_\mathbf{d}[(64 + l_B)..(63 + l_B + l_E)] \\
 M &=& I_\mathbf{d}[(64 + l_B + l_E)..(|I_\mathbf{d}| - 1)] \\
-\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| < 64 + l_B + l_E \\
+\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| < 64 + l_B + l_E\,\vee\,M\le B \\
 g_r &=& G_{modexpbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + |M|^2 |E| / G_{quaddivisor} \\
 \mathbf{o} &=&
 \begin{cases}

--- a/Paper.tex
+++ b/Paper.tex
@@ -1407,8 +1407,10 @@ g_r &=& 15 + 3\Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil\\
 \end{eqnarray}
 
 The fifth contract performs arbitrary-precision addition on non-negative integers.
-The first word in the input specifies the number of bytes that the first non-negative integer $X$ occupies.
+The first word in the input specifies the number of bytes that the first non-negative integer $X$ occupies.  The rest of the input is interpreted as $Y$.
+Both $X$ and $Y$ are interpreted as a natural number encoded as byte sequences in the big-endian way.
 The result is represented in the smallest possible number of bytes.  The first byte in the output, if exists, is never zero.
+The input and output formats are the same for $\Xi_{\mathtt{SUB}}$, $\Xi_{\mathtt{MUL}}$ and $\Xi_{\mathtt{DIV}}$ as well.
 
 \begin{eqnarray}
 \Xi_{\mathtt{ADD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
@@ -1416,7 +1418,9 @@ The result is represented in the smallest possible number of bytes.  The first b
 g_r &=& G_{addsubbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil \\
 \mathbf{o} &=& \mathtt{\tiny BE}(X + Y) \\
 X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
-Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)]
+l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
+Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
+l_Y &=& |I_\mathbf{d}| - 32 - l_X
 \end{eqnarray}
 
 The sixth contract performs arbitrary-precision subtraction on non-negative integers.  This is similar to the addition.  The subtraction contract halts exceptionally if the result would be negative.
@@ -1428,7 +1432,9 @@ The sixth contract performs arbitrary-precision subtraction on non-negative inte
 g_r &=& G_{addsubbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil \\
 \mathbf{o} &=& \mathtt{\tiny BE}(X - Y) \\
 X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
-Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)]
+l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
+Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
+l_Y &=& |I_\mathbf{d}| - 32 - l_X
 \end{eqnarray}
 
 The seventh contract performs arbitrary-precision multiplication on non-negative integers.  The input format is the same as that of the addition contract.
@@ -1436,12 +1442,12 @@ The seventh contract performs arbitrary-precision multiplication on non-negative
 \begin{eqnarray}
 \Xi_{\mathtt{MUL}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
 \Xi_{\mathtt{MUL}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
-g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + \ell_X \ell_Y / G_{quaddivisor} \\
+g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + l_X l_Y / G_{quaddivisor} \\
 \mathbf{o} &=& \mathtt{\tiny BE}(X \times Y) \\
 X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
-\ell_X &=& I_\mathbf{d}[0..31] \\
+l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
 Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
-\ell_Y &=& |I_\mathbf{d}| - 32 - \ell_X
+l_Y &=& |I_\mathbf{d}| - 32 - l_X
 \end{eqnarray}
 
 The eigth contract performs arbitrary-precision division on non-negative integers.  The definition is similar to that of the multiplication contract.
@@ -1449,27 +1455,33 @@ The eigth contract performs arbitrary-precision division on non-negative integer
 \begin{eqnarray}
 \Xi_{\mathtt{DIV}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
 \Xi_{\mathtt{DIV}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| - 32 <  I_\mathbf{d}[0..31] \\
-g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + \ell_X \ell_Y / G_{quaddivisor} \\
+g_r &=& G_{muldivbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + l_X l_Y / G_{quaddivisor} \\
 \mathbf{o} &=&
 \begin{cases}
  () & \text{if} \  Y = 0 \\
  \mathtt{\tiny BE}\Big(\big\lfloor \dfrac X Y \big\rfloor\Big) & \text{otherwise}
 \end{cases} \\
 X &=& I_\mathbf{d}[32..(32 + I_\mathbf{d}[0..31] - 1)] \\
-\ell_X &=& I_\mathbf{d}[0..31] \\
+l_X &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
 Y &=& I_\mathbf{d}[(32 + I_\mathbf{d}[0..31])..(|I_\mathbf{d}| - 1)] \\
-\ell_Y &=& |I_\mathbf{d}| - 32 - \ell_X
+l_Y &=& |I_\mathbf{d}| - 32 - l_X
 \end{eqnarray}
 
 The ninth contract performs arbitrary-precision exponentiation under modulo.  Here, $0 ^ 0$ is taken to be one.
+The first word in the input specifies the number of bytes that the first non-negative integer $B$ occupies.
+The second word in the input specifies the number of bytes that the second non-negative integer $E$ occupies.
+These two words are followed by $B$ and $E$; and the rest of the input is interpreted as the third non-negative integer $M$.
+All non-negative integers $B$, $E$ $M$ are encoded as byte sequences in the big-endian way.
+The output format is the same as the precompiled contract $\Xi_{\mathtt{ADD}}$.
+
 \begin{eqnarray}
 \Xi_{\mathtt{EXPMOD}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{except:}\\
-\ell_B &=& I_\mathbf{d}[0..31] \\
-\ell_E &=& I_\mathbf{d}[32..63] \\
-B &=& I_\mathbf{d}[64..(63 + \ell_B)] \\
-E &=& I_\mathbf{d}[(64 + \ell_B)..(63 + \ell_B + \ell_E)] \\
-M &=& I_\mathbf{d}[(64 + \ell_B + \ell_E)..(|I_\mathbf{d}| - 1)] \\
-\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| < 64 + \ell_B + \ell_E \\
+l_B &=& I_\mathbf{d}[0..31] \in \mathbb{P}_{256} \\
+l_E &=& I_\mathbf{d}[32..63] \in \mathbb{P}_{256} \\
+B &=& I_\mathbf{d}[64..(63 + l_B)] \\
+E &=& I_\mathbf{d}[(64 + l_B)..(63 + l_B + l_E)] \\
+M &=& I_\mathbf{d}[(64 + l_B + l_E)..(|I_\mathbf{d}| - 1)] \\
+\Xi_{\mathtt{EXPMOD}}(\boldsymbol{\sigma}, g, I) &\equiv& (\varnothing, 0, A^0, ()) \quad \text{if} \quad |I_\mathbf{d}| < 64 + l_B + l_E \\
 g_r &=& G_{modexpbase} + G_{arithword} \Big\lceil \dfrac{|I_\mathbf{d}|}{32} \Big\rceil + |M|^2 |E| / G_{quaddivisor} \\
 \mathbf{o} &=&
 \begin{cases}


### PR DESCRIPTION
If merged, this would solve #235 as part of the Metropolis changes #229.

This is a re-incarnation of #258.  Comments given there are addressed.