### PR TITLE
Spurious Dragon: EIP160 Update the fee of EXP

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1478,7 +1478,7 @@ $G_{callvalue}$ & 9000 & Paid for a non-zero value transfer as part of the {\sma
 $G_{callstipend}$ & 2300 & A stipend for the called contract subtracted from $G_{callvalue}$ for a non-zero value transfer. \\
 $G_{newaccount}$ & 25000 & Paid for a {\small CALL} or {\small SELFDESTRUCT} operation which creates an account. \\
 $G_{exp}$ & 10 & Partial payment for an {\small EXP} operation. \\
-$G_{expbyte}$ & 10 & Partial payment when multiplied by $\lceil\log_{256}(exponent)\rceil$ for the {\small EXP} operation. \\
+$G_{expbyte}$ & 50 & Partial payment when multiplied by $\lceil\log_{256}(exponent)\rceil$ for the {\small EXP} operation. \\
 $G_{memory}$ & 3 & Paid for every additional word when expanding memory. \\
 $G_\text{txcreate}$ & 32000 & Paid by all contract-creating transactions after the {\it Homestead transition}.\\
 $G_{txdatazero}$ & 4 & Paid for every zero byte of data or code for a transaction. \\


### PR DESCRIPTION
This follows the protocol change https://github.com/ethereum/EIPs/issues/160 as part of Spurious Dragon.

I've created `homestead` out of `master`, and filing this PR on `master` because this change has already been applied in the mainnet.