### PR TITLE
Detect merge conflicts in the build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,12 @@ fi
 
 echo "\newcommand{\YellowPaperVersionNumber}{$REV}" > Version.tex
 
+if grep '=========' Paper.tex
+then
+  echo "merge conflict?"
+  exit 1
+fi
+
 mkdir -p build
 pdflatex -output-directory=build -interaction=errorstopmode -halt-on-error Paper.tex && \
 bibtex build/Paper && \


### PR DESCRIPTION
After this PR, the build script fails when the LaTeX source contains `=======`.