### PR TITLE
Metropolis: EIP98 option 1

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -337,9 +337,8 @@ R \equiv (R_u, R_b, R_\mathbf{l})
 
 The function $L_R$ trivially prepares a transaction receipt for being transformed into an RLP-serialised byte array:
 \begin{equation}
-L_R(R) \equiv (0 \in \mathbb{B}_{256}, R_u, R_b, R_\mathbf{l})
+L_R(R) \equiv (R_u, R_b, R_\mathbf{l})
 \end{equation}
-where $0 \in \mathbb{B}_{256}$ replaces the pre-transaction state root that existed in previous versions of the protocol.
 
 We assert $R_u$, the cumulative gas used is a positive integer and that the logs Bloom, $R_b$, is a hash of size 2048 bits (256 bytes):
 \begin{equation}


### PR DESCRIPTION
Before this PR, the metropolis branch contained EIP98 option 2, but the consensus now is option 1.