### PR TITLE
Contract creation on non-empty code or non-zero nonce throws an exception

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -760,7 +760,7 @@ g^{**} - c & \text{otherwise} \\
 1 & \text{otherwise}
 \end{cases} \\
 \nonumber \text{where} \\
-F &\equiv \big((\boldsymbol{\sigma}^{**} = \varnothing \ \wedge\ \mathbf{o} = \varnothing) \vee\  g^{**} < c \ \vee\  |\mathbf{o}| > 24576\big)
+F \equiv &\big(\boldsymbol{\sigma}[a]_c \neq \texttt{\small KEC}\big(()\big) \ \vee\ \boldsymbol{\sigma}[a]_n \neq 0 \ \vee\ (\boldsymbol{\sigma}^{**} = \varnothing \ \wedge\ \mathbf{o} = \varnothing) \\\nonumber  & \vee\ g^{**} < c \ \vee\  |\mathbf{o}| > 24576\big)
 \end{align}
 
 The exception in the determination of $\boldsymbol{\sigma}'$ dictates that $\mathbf{o}$, the resultant byte sequence from the execution of the initialisation code, specifies the final body code for the newly-created account.


### PR DESCRIPTION
This implements a protocol change which is very hard to hit anyway.  The idea is to avoid overwriting contracts even when the calculated address coincides with existing something.  Here "existing something" is an account with non-zero nonce or non-empty code.  This is consistent with EIP86 planned in Constantinople.

There have been some test failures happening only on the address-collision cases, but most probably the time spent there is wasted because keccak256 collisions cause far bigger problems anyway.  It makes sense to make the protocol specification simpler for the address collision case.