### PR TITLE
URLs

### DIFF
--- a/Biblio.bib
+++ b/Biblio.bib
@@ -54,7 +54,7 @@
 	note = {{https://web.archive.org/web/20170810035057/https://www.iacr.org/archive/ches2004/31560117/31560117.pdf}},
 	BookTitle = {{Cryptographic Hardware and Embedded Systems-CHES 2004}},
 	Publisher = {{Springer}},
-	author = {Gura, Nils and Patel, Arun and Wander, Arvinderpal and Eberle, Hans and Shantz, Sheueling Chang},
+	author = {Gura, Nils and Patel, Arun and Wander, Arvinderpal and Eberle, Hans and Sheueling Chang Shantz},
 	title = {{Comparing elliptic curve cryptography and RSA on 8-bit CPUs}},
 	pages = {119-132},
 	year = {{2004}},
@@ -70,7 +70,7 @@
 @Misc{vishnumurthy03karma:a,
     url = {{https://www.cs.cornell.edu/people/egs/papers/karma.pdf}},
     note = {{https://web.archive.org/web/20170810031834/https://www.cs.cornell.edu/people/egs/papers/karma.pdf}},
-    author = {Vishnumurthy, Vivek; Chandrakumar, Sangeeth; and Sirer, Emin Gün},
+    author = {Vishnumurthy, Vivek and Chandrakumar, Sangeeth and Gün Sirer, Emin},
     title = {KARMA: A Secure Economic Framework for Peer-to-Peer Resource Sharing},
     year = {2003}
 }
@@ -118,7 +118,7 @@
 @article{mastercoin2013willett,
 	url = {{https://github.com/mastercoin-MSC/spec}},
 	note = {{https://web.archive.org/web/20170810035927/https://github.com/OmniLayer/spec}},
-	author = {J. R. Willett},
+	author = {Willett, J. R.},
 	title = {{MasterCoin Complete Specification}},
 	year = {{2013}},
 }
@@ -207,4 +207,4 @@
 	year = {{1991}},
 }
 
-Style guide: https://en.wikibooks.org/wiki/LaTeX/Bibliography_Management#Authors
+Style guide: https://en.wikibooks.org/wiki/LaTeX/Bibliography_Management

--- a/Biblio.bib
+++ b/Biblio.bib
@@ -1,9 +1,52 @@
-@Misc{cryptoeprint:2013:881,
-	Url = {{Cryptology ePrint Archive, Report 2013/881}},
-	Note = {{http://eprint.iacr.org/}},
-	author = {Sompolinsky, Yonatan and Zohar, Aviv},
-	title = {{Accelerating Bitcoin{'}s Transaction Processing. Fast Money Grows on Trees, Not Chains}},
-	year = {{2013}},
+@misc{ECDSAWikipedia,
+	url = "https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm",
+	note = "https://web.archive.org/web/20170916033830/https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm",
+	title = {{Elliptic Curve Digital Signature Algorithm}},
+	publisher = "Wikipedia",
+	date = "12 September 2017",
+}
+
+@misc{ECDSAcerticom,
+	url = "http://cs.ucsb.edu/~koc/ccs130h/notes/ecdsa-cert.pdf",
+	note = "https://web.archive.org/save/http://cs.ucsb.edu/~koc/ccs130h/notes/ecdsa-cert.pdf",
+	title = {{The Elliptic Curve Digital Signature Algorithm (ECDSA)}},
+	publisher = {{Certicom Research}},
+	location = "Canada",
+	author = "Don Johnson and Alfred Menezes and Scott Vanstone",
+	year = "2001",
+}
+
+@misc{secp256k1BitcoinWiki2016,
+	url = "https://en.bitcoin.it/wiki/Secp256k1",
+	note = "https://web.archive.org/web/20170916032105/https://en.bitcoin.it/wiki/Secp256k1",
+	title = {{Secp256k1}},
+	publisher = {{bitcoinwiki}},
+	date = {{4 August 2016}},
+}
+
+@misc{secp256k1StackExchange2014,
+	url = "https://bitcoin.stackexchange.com/a/21911/48875",
+	note = "https://web.archive.org/web/20170916031457/https://bitcoin.stackexchange.com/questions/21907/what-does-the-curve-used-in-bitcoin-secp256k1-look-like/21911",
+	author = "Pieter Wuille",
+	title = {{What does the curve used in Bitcoin, secp256k1, look like?}},
+	year = "2014",
+	publisher = {{Bitcoin Stack Exchange}},
+}
+
+@misc{npmElectrum2017,
+	url = {{https://www.npmjs.com/package/electrum}},
+	note = {{https://web.archive.org/save/https://www.npmjs.com/package/electrum}},
+	author = {Arnaud, Pierre and Schroeter, Mathieu and Le Barbare, Sam},
+	title = {{Electrum}},
+	year = {{2017}},
+}
+
+@misc{cryptoeprint:2013:881,
+    author = {Sompolinsky, Yonatan and Aviv Zohar},
+    title = {{Accelerating Bitcoin's Transaction Processing. Fast Money Grows on Trees, Not Chains}},
+    howpublished = {Cryptology ePrint Archive, Report 2013/881},
+    year = {2013},
+    note = {\url{http://eprint.iacr.org/2013/881}},
 }
 
 @InCollection{gura2004comparing,
@@ -163,3 +206,5 @@
 	title = {{Fowler–Noll–Vo hash function}},
 	year = {{1991}},
 }
+
+Style guide: https://en.wikibooks.org/wiki/LaTeX/Bibliography_Management#Authors

--- a/Biblio.bib
+++ b/Biblio.bib
@@ -1,12 +1,14 @@
 @Misc{cryptoeprint:2013:881,
-	Note = {{http://eprint.iacr.org/}},
 	Url = {{Cryptology ePrint Archive, Report 2013/881}},
+	Note = {{http://eprint.iacr.org/}},
 	author = {Sompolinsky, Yonatan and Zohar, Aviv},
 	title = {{Accelerating Bitcoin{'}s Transaction Processing. Fast Money Grows on Trees, Not Chains}},
 	year = {{2013}},
 }
 
 @InCollection{gura2004comparing,
+	url = {{https://www.iacr.org/archive/ches2004/31560117/31560117.pdf}},
+	note = {{https://web.archive.org/web/20170810035057/https://www.iacr.org/archive/ches2004/31560117/31560117.pdf}},
 	BookTitle = {{Cryptographic Hardware and Embedded Systems-CHES 2004}},
 	Publisher = {{Springer}},
 	author = {Gura, Nils and Patel, Arun and Wander, Arvinderpal and Eberle, Hans and Shantz, Sheueling Chang},
@@ -23,12 +25,16 @@
 }
 
 @Misc{vishnumurthy03karma:a,
-    author = {Vivek Vishnumurthy and Sangeeth Chandrakumar and Emin Gün Sirer},
+    url = {{https://www.cs.cornell.edu/people/egs/papers/karma.pdf}},
+    note = {{https://web.archive.org/web/20170810031834/https://www.cs.cornell.edu/people/egs/papers/karma.pdf}},
+    author = {Vishnumurthy, Vivek; Chandrakumar, Sangeeth; and Sirer, Emin Gün},
     title = {KARMA: A Secure Economic Framework for Peer-to-Peer Resource Sharing},
     year = {2003}
 }
 
 @InProceedings{dwork92pricingvia,
+    url = {{http://www.wisdom.weizmann.ac.il/~naor/PAPERS/pvp.pdf}},
+    note = {{https://web.archive.org/web/20170810035254/http://www.wisdom.weizmann.ac.il/~naor/PAPERS/pvp.pdf}},
     author = {Cynthia Dwork and Moni Naor},
     title = {Pricing via processing or combatting junk mail},
     booktitle = {In 12th Annual International Cryptology Conference},
@@ -37,6 +43,7 @@
 }
 
 @Article{nakamoto2008bitcoin,
+	url = {{http://nakamotoinstitute.org/bitcoin/}},
 	author = {Nakamoto, Satoshi},
 	title = {{Bitcoin: A peer-to-peer electronic cash system}},
 	journal = {{Consulted}},
@@ -46,12 +53,15 @@
 }
 
 @Misc{sprankel2013technical,
+	url = {{http://www.coderblog.de/wp-content/uploads/technical-basis-of-digital-currencies.pdf}},
+	note = {{https://web.archive.org/web/20170810025028/http://www.coderblog.de/wp-content/uploads/technical-basis-of-digital-currencies.pdf}},
 	author = {Sprankel, Simon},
 	title = {{Technical Basis of Digital Currencies}},
 	year = {{2013}},
 }
 
 @Article{aron2012bitcoin,
+	url = {{http://www.sciencedirect.com/science/article/pii/S0262407912601055}},
 	Publisher = {{Elsevier}},
 	author = {Aron, Jacob},
 	title = {{BitCoin software finds new life}},
@@ -64,6 +74,7 @@
 
 @article{mastercoin2013willett,
 	url = {{https://github.com/mastercoin-MSC/spec}},
+	note = {{https://web.archive.org/web/20170810035927/https://github.com/OmniLayer/spec}}
 	author = {J. R. Willett},
 	title = {{MasterCoin Complete Specification}},
 	year = {{2013}},
@@ -71,12 +82,15 @@
 
 @article{colouredcoins2012rosenfeld,
 	url = {{https://bitcoil.co.il/BitcoinX.pdf}},
+	note = {{https://web.archive.org/web/20170810040120/https://bitcoil.co.il/BitcoinX.pdf}}
 	author = {Meni Rosenfeld},
 	title = {{Overview of Colored Coins}},
 	year = {{2012}},
 }
 
 @incollection{boutellier2014pirates,
+	url = {{https://www.springer.com/gb/book/9783319040158}},
+	note = {{URL available at http://wiki.erights.org/wiki/Documentation. https://web.archive.org/web/20170810040208/https://www.springer.com/gb/book/9783319040158}},
 	booktitle = {{Growth Through Innovation}},
 	publisher = {{Springer}},
 	author = {Boutellier, Roman and Heinzen, Mareike},
@@ -86,6 +100,8 @@
 }
 
 @Article{szabo1997formalizing,
+	url = {{http://firstmonday.org/ojs/index.php/fm/article/view/548}},
+	note = {{https://web.archive.org/web/20170810042659/http://firstmonday.org/ojs/index.php/fm/article/view/548}},
 	author = {Szabo, Nick},
 	title = {{Formalizing and securing relationships on public networks}},
 	journal = {{First Monday}},
@@ -95,6 +111,7 @@
 }
 
 @InProceedings{miller1997future,
+	url = {{https://drive.google.com/file/d/0Bw0VXJKBgYPMS0J2VGIyWWlocms/edit?usp=sharing}},
 	BookTitle = {{paper delivered at the Extro 3 Conference (August 9)}},
 	author = {Miller, Mark},
 	title = {{The Future of Law}},
@@ -103,6 +120,7 @@
 
 @article{buterin2013ethereum,
 	url = {{https://github.com/ethereum/wiki/wiki/White-Paper}},
+	note = {{https://github.com/ethereum/wiki/wiki/White-Paper}},
 	author = {Vitalik Buterin},
 	title = {{Ethereum: A Next-Generation Smart Contract and Decentralized Application Platform}},
 	year = {{2013}},
@@ -110,20 +128,23 @@
 
 @article{back2002hashcash,
 	url = {{http://www.hashcash.org/papers/amortizable.pdf}},
+	note = {{https://web.archive.org/web/20170810043047/http://www.hashcash.org/papers/amortizable.pdf}},
 	author = {Adam Back},
 	title = {{Hashcash - Amortizable Publicly Auditable Cost-Functions}},
 	year = {{2002}},
 }
 
 @article{hashimoto,
-	url = {{https://mirrorx.com/files/hashimoto.pdf}},
+	url = {{https://pdfs.semanticscholar.org/3b23/7cc60c1b9650e260318d33bec471b8202d5e.pdf}},
+	note = {{https://web.archive.org/web/20170810043640/https://pdfs.semanticscholar.org/3b23/7cc60c1b9650e260318d33bec471b8202d5e.pdf. Dead original link as of 10 August 2017: https://mirrorx.com/files/hashimoto.pdf}},
 	author = {Thaddeus Dryja},
 	title = {{Hashimoto: I/O bound proof of work}},
 	year = {{2014}},
 }
 
 @article{dagger,
-	url = {{http://vitalik.ca/ethereum/dagger.html}},
+	url = {{http://www.hashcash.org/papers/dagger.html}},
+	note = {{https://web.archive.org/web/20170810043955/http://www.hashcash.org/papers/dagger.html. Dead original link as of 10 August 2017: http://vitalik.ca/ethereum/dagger.html}},
 	author = {Vitalik Buterin},
 	title = {{Dagger: A Memory-Hard to Compute, Memory-Easy to Verify Scrypt Alternative}},
 	year = {{2013}},
@@ -131,6 +152,7 @@
 
 @article{lerner2014randmemohash,
 	url = {{http://www.hashcash.org/papers/memohash.pdf}},
+	note = {{https://web.archive.org/web/20170810044110/http://www.hashcash.org/papers/memohash.pdf}},
 	author = {Sergio Demian Lerner},
 	title = {{Strict Memory Hard Hashing Functions}},
 	year = {{2014}},

--- a/Biblio.bib
+++ b/Biblio.bib
@@ -33,8 +33,8 @@
 }
 
 @InProceedings{dwork92pricingvia,
-    url = {{http://www.wisdom.weizmann.ac.il/~naor/PAPERS/pvp.pdf}},
     note = {{https://web.archive.org/web/20170810035254/http://www.wisdom.weizmann.ac.il/~naor/PAPERS/pvp.pdf}},
+    url = {{http://www.wisdom.weizmann.ac.il/~naor/PAPERS/pvp.pdf}},
     author = {Cynthia Dwork and Moni Naor},
     title = {Pricing via processing or combatting junk mail},
     booktitle = {In 12th Annual International Cryptology Conference},
@@ -74,7 +74,7 @@
 
 @article{mastercoin2013willett,
 	url = {{https://github.com/mastercoin-MSC/spec}},
-	note = {{https://web.archive.org/web/20170810035927/https://github.com/OmniLayer/spec}}
+	note = {{https://web.archive.org/web/20170810035927/https://github.com/OmniLayer/spec}},
 	author = {J. R. Willett},
 	title = {{MasterCoin Complete Specification}},
 	year = {{2013}},
@@ -82,7 +82,7 @@
 
 @article{colouredcoins2012rosenfeld,
 	url = {{https://bitcoil.co.il/BitcoinX.pdf}},
-	note = {{https://web.archive.org/web/20170810040120/https://bitcoil.co.il/BitcoinX.pdf}}
+	note = {{https://web.archive.org/web/20170810040120/https://bitcoil.co.il/BitcoinX.pdf}},
 	author = {Meni Rosenfeld},
 	title = {{Overview of Colored Coins}},
 	year = {{2012}},
@@ -120,7 +120,6 @@
 
 @article{buterin2013ethereum,
 	url = {{https://github.com/ethereum/wiki/wiki/White-Paper}},
-	note = {{https://github.com/ethereum/wiki/wiki/White-Paper}},
 	author = {Vitalik Buterin},
 	title = {{Ethereum: A Next-Generation Smart Contract and Decentralized Application Platform}},
 	year = {{2013}},


### PR DESCRIPTION
For archiving purposes, I've added live URLs and archived URLS (where possible) for all references. While I understand that including URLS is not usually a standard style for non-web texts, I think it is good to include them to make it easier to access the references and provide an archive URL to provide a citation that will be accessible for perpetuity.