### PR TITLE
Fix minGasLimit to 5000

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -463,7 +463,7 @@ The canonical gas limit $H_l$ of a block of header $H$ must fulfil the relation:
 \begin{eqnarray}
 & & H_l < {P(H)_H}_l + \left\lfloor\frac{{P(H)_H}_l}{1024}\right\rfloor \quad \wedge \\
 & & H_l > {P(H)_H}_l - \left\lfloor\frac{{P(H)_H}_l}{1024}\right\rfloor \quad \wedge \\
-& & H_l \geqslant 125000
+& & H_l \geqslant 5000
 \end{eqnarray}
 
 $H_s$ is the timestamp of block $H$ and must fulfil the relation:


### PR DESCRIPTION
Fix according to https://github.com/ethereum/yellowpaper/issues/317
Major clients implement a minGasLimit of 5000 instead of 125000 as specified in the paper

https://github.com/ethereum/go-ethereum/blob/master/params/protocol_params.go#L76
https://github.com/ethereum/cpp-ethereum/blob/develop/libethereum/GenesisInfo.cpp#L36
https://github.com/paritytech/parity/blob/master/ethcore/res/ethereum/foundation.json#L147
https://github.com/ethereum/ethereumj/blob/develop/ethereumj-core/src/main/java/org/ethereum/config/blockchain/FrontierConfig.java#L44

