### PR TITLE
Improve explanation of "recovery id" used in ECDSARECOVER

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1404,7 +1404,7 @@ We assert the functions $\mathtt{\small ECDSASIGN}$, $\mathtt{\small ECDSARECOVE
 \mathtt{\small ECDSARECOVER}(e \in \mathbb{B}_{32}, v \in \mathbb{B}_{1}, r \in \mathbb{B}_{32}, s \in \mathbb{B}_{32}) & \equiv & p_u \in \mathbb{B}_{64}
 \end{eqnarray}
 
-Where $p_u$ is the public key, assumed to be a byte array of size 64 (formed from the concatenation of two positive integers each $< 2^{256}$) and $p_r$ is the private key, a byte array of size 32 (or a single positive integer in the aforementioned range). It is assumed that $v$ is the `recovery id', a 1 byte value specifying the sign and finiteness of the curve point; this value is in the range of $[27, 30]$, however we declare the upper two possibilities, representing infinite values, invalid.
+Where $p_u$ is the public key, assumed to be a byte array of size 64 (formed from the concatenation of two positive integers each $< 2^{256}$) and $p_r$ is the private key, a byte array of size 32 (or a single positive integer in the aforementioned range). It is assumed that $v$ is the `recovery id', a 1 byte value specifying the sign and finiteness of the curve point for which $r$ is the x value. This value is in the range of $[27, 30]$, however we declare the upper two possibilities, representing infinite values, invalid.
 
 \newcommand{\slimit}{\ensuremath{\text{s-limit}}}
 


### PR DESCRIPTION
r is the calculated x-coordinate  of the "curve point" in the ECDSASIGN function.

Given an x-coordinate, two possible curve points exist. One with a negative y-value
and one with a positive y-value. The recovery id specifies which of the two possible y-values
is the correct one.