### PR TITLE
Add Paper.out to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Paper.aux
 Paper.bbl
 Paper.blg
 Paper.log
+Paper.out
 Paper.pdf
 Version.tex
 


### PR DESCRIPTION
`./build.sh` generates an intermediate _Paper.out_ file which ought to be ignored.