### PR TITLE
Make sure that divisions and modulo operations are not subject to mod 2^{256}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 before_install:
 - sudo apt-get -qq update
 - sudo apt-get install texlive texlive-latex3
+- sudo apt install texlive-latex-extra
 script:
 - ./build.sh
 deploy:

--- a/Paper.tex
+++ b/Paper.tex
@@ -1583,18 +1583,20 @@ Here given are the various exceptions to the state transition rules given in sec
 \midrule
 0x04 & {\small DIV} & 2 & 1 & Integer division operation. \\
 &&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv \begin{cases}0 & \text{if} \quad \boldsymbol{\mu}_\mathbf{s}[1] = 0\\ \lfloor\boldsymbol{\mu}_\mathbf{s}[0] \div \boldsymbol{\mu}_\mathbf{s}[1]\rfloor & \text{otherwise}\end{cases}$  \\
+&&&& where division is not subject to modulo $2^{256}$. \\
 \midrule
 0x05 & {\small SDIV} & 2 & 1 & Signed integer division operation (truncated). \\
 &&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv \begin{cases}0 & \text{if} \quad \boldsymbol{\mu}_\mathbf{s}[1] = 0\\ -2^{255} & \text{if} \quad \boldsymbol{\mu}_\mathbf{s}[0] = -2^{255} \wedge \quad \boldsymbol{\mu}_\mathbf{s}[1] = -1\\ \mathbf{sgn} (\boldsymbol{\mu}_\mathbf{s}[0] \div \boldsymbol{\mu}_\mathbf{s}[1]) \lfloor |\boldsymbol{\mu}_\mathbf{s}[0] \div \boldsymbol{\mu}_\mathbf{s}[1]| \rfloor & \text{otherwise}\end{cases}$  \\
-&&&& Where all values are treated as two's complement signed 256-bit integers. \\
+&&&& Where all values are treated as two's complement signed 256-bit integers and division is not subject to modulo $2^{256}.$ \\
 &&&& Note the overflow semantic when $-2^{255}$ is negated.\\
 \midrule
 0x06 & {\small MOD} & 2 & 1 & Modulo remainder operation. \\
 &&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv \begin{cases}0 & \text{if} \quad \boldsymbol{\mu}_\mathbf{s}[1] = 0\\ \boldsymbol{\mu}_\mathbf{s}[0] \bmod \boldsymbol{\mu}_\mathbf{s}[1] & \text{otherwise}\end{cases}$  \\
+&&&& where $\mod$ is not subject to modulo $2^{256}$. \\
 \midrule
 0x07 & {\small SMOD} & 2 & 1 & Signed modulo remainder operation. \\
 &&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv \begin{cases}0 & \text{if} \quad \boldsymbol{\mu}_\mathbf{s}[1] = 0\\ \mathbf{sgn} (\boldsymbol{\mu}_\mathbf{s}[0]) |\boldsymbol{\mu}_\mathbf{s}[0]| \bmod |\boldsymbol{\mu}_\mathbf{s}[1]| & \text{otherwise}\end{cases}$  \\
-&&&& Where all values are treated as two's complement signed 256-bit integers. \\
+&&&& Where all values are treated as two's complement signed 256-bit integers and $\mod$ is not subject to modulo $2^{256}$. \\
 \midrule
 0x08 & {\small ADDMOD} & 3 & 1 & Modulo addition operation. \\
 &&&& $\boldsymbol{\mu}'_\mathbf{s}[0] \equiv \begin{cases}0 & \text{if} \quad \boldsymbol{\mu}_\mathbf{s}[2] = 0\\ (\boldsymbol{\mu}_\mathbf{s}[0] + \boldsymbol{\mu}_\mathbf{s}[1]) \mod \boldsymbol{\mu}_\mathbf{s}[2] & \text{otherwise}\end{cases}$  \\


### PR DESCRIPTION
At the beginning of the table of instructions, it's written that all operations are subject to modulo 256-bit, so when the modulo is not applicable, the exception should be mentioned.