### PR TITLE
Remove unnecessary comment

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -35,7 +35,6 @@
 \usepackage[english]{babel}
 \usepackage[autostyle]{csquotes}
 \MakeOuterQuote{"}
-% Put before hyperref
 
 \input{Version.tex}
 


### PR DESCRIPTION
Given that these commands are after the hyperref package and haven't caused an issue, clearly this comment (to put them before) can be removed.