### PR TITLE
Swap bibliographystyle and bibliography

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1250,8 +1250,8 @@ Many thanks to Aeron Buchanan for authoring the \textit{Homestead} revisions, Ch
 
 The source of this paper is maintained at \url{https://github.com/ethereum/yellowpaper/}. An auto-generated PDF is located at \url{https://ethereum.github.io/yellowpaper/paper.pdf}.
 
-\bibliography{Biblio}
 \bibliographystyle{plainnat}
+\bibliography{Biblio}
 
 \end{multicols}
 


### PR DESCRIPTION
Test for #541. Stiill has: Package natbib Warning: Citation `buterin2013ethereum' on page 1 undefined on i
nput line 99.

But at any rate this should be merged in order to comply with style conventions.

https://en.wikibooks.org/wiki/LaTeX/Bibliography_Management