### PR TITLE
Update and rename build.sh to b.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
 - sudo apt-get install texlive texlive-latex3
 - sudo apt install texlive-latex-extra
 script:
-- ./build.sh
+- ./b.sh
 deploy:
   provider: script
   script: ./travis_deploy.sh

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The paper also comes as a single ``latex`` file ``Paper.tex``, which is built as
 ```
 git clone https://github.com/ethereum/yellowpaper.git
 cd yellowpaper
-./build.sh
+./b.sh
 ```
 This will create a PDF version of the Yellow Paper. Following building, you can also use standard `pdflatex` tools like http://latex.informatik.uni-halle.de/latex-online/latex.php for compiling/preview.
 

--- a/b.sh
+++ b/b.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# b.sh is short for build.sh. Having a very short file name saves time typing this command many times into the terminal, e.g. when making a small change, then building, and repeating these two steps many times.
 set -e
 
 if [ -d ".git" ]; then


### PR DESCRIPTION
b.sh is short for build.sh. Having a very short file name saves time typing this command many times into the terminal, e.g. when making a small change, then building, and repeating these two steps many times.