### PR TITLE
Use build/ directory for building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,8 +16,9 @@ fi
 
 echo "\newcommand{\YellowPaperVersionNumber}{$REV}" > Version.tex
 
-pdflatex -interaction=errorstopmode -halt-on-error Paper.tex && \
-bibtex Paper && \
-pdflatex -interaction=errorstopmode -halt-on-error Paper.tex && \
-pdflatex -interaction=errorstopmode -halt-on-error Paper.tex && \
-pdflatex -interaction=errorstopmode -halt-on-error Paper.tex
+mkdir build
+pdflatex -output-directory=build -interaction=errorstopmode -halt-on-error Paper.tex && \
+bibtex build/Paper && \
+pdflatex -output-directory=build -interaction=errorstopmode -halt-on-error Paper.tex && \
+pdflatex -output-directory=build -interaction=errorstopmode -halt-on-error Paper.tex && \
+pdflatex -output-directory=build -interaction=errorstopmode -halt-on-error Paper.tex

--- a/travis_deploy.sh
+++ b/travis_deploy.sh
@@ -12,7 +12,7 @@ echo "# Automatic build" > README.md
 echo "Built pdf from \`$SHA\`. See https://github.com/ethereum/yellowpaper/ for details." >> README.md
 echo "The generated pdf is here: https://ethereum.github.io/yellowpaper/paper.pdf" >> README.md
 echo '<html><head><meta http-equiv="refresh" content="0; url=paper.pdf" /></head><body></body></html>' > index.html
-mv Paper.pdf paper.pdf
+mv build/Paper.pdf paper.pdf
 git add -f README.md index.html paper.pdf
 git commit -m "Built pdf from {$SHA}."
 


### PR DESCRIPTION
This uses a separate directory for building. This makes development cleaner because you can get a clean state by removing the `build/` directory.