### PR TITLE
Add option to build white paper

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -42,7 +42,10 @@
 \usepackage[autostyle]{csquotes}
 \MakeOuterQuote{"}
 
-\input{Version.tex}
+% Default rendering options
+\definecolor{pagecolor}{rgb}{1,0.98,0.9}
+\def\YellowPaperVersionNumber{unknown revision}
+\IfFileExists{Options.tex}{\input{Options.tex}}
 
 \newcommand{\hcancel}[1]{%
     \tikz[baseline=(tocancel.base)]{
@@ -51,7 +54,6 @@
     }%
 }%
 
-\definecolor{lightyellow}{rgb}{1,0.98,0.9}
 
 \DeclarePairedDelimiter{\ceil}{\lceil}{\rceil}
 \newcommand*\eg{e.g.\@\xspace}
@@ -59,7 +61,7 @@
 \newcommand*\ie{i.e.\@\xspace}
 %\renewcommand{\itemhook}{\setlength{\topsep}{0pt}  \setlength{\itemsep}{0pt}\setlength{\leftmargin}{15pt}}
 
-\title{Ethereum: A Secure Decentralised Generalised Transaction Ledger \\ {\smaller \textbf{Byzantium version \YellowPaperVersionNumber{}}}}
+\title{Ethereum: A Secure Decentralised Generalised Transaction Ledger \\ {\smaller \textbf{Byzantium version \YellowPaperVersionNumber}}}
 \author{
     Dr. Gavin Wood\\
     Founder, Ethereum \& Parity\\
@@ -67,7 +69,7 @@
 }
 \begin{document}
 
-\pagecolor{lightyellow}
+\pagecolor{pagecolor}
 
 \begin{abstract}
 The blockchain paradigm when coupled with cryptographically-secured transactions has demonstrated its utility through a number of projects, with Bitcoin being one of the most notable ones. Each such project can be seen as a simple application on a decentralised, but singleton, compute resource. We can call this paradigm a transactional singleton machine with shared-state.

--- a/build.sh
+++ b/build.sh
@@ -1,18 +1,31 @@
 #!/usr/bin/env bash
 
+##
+## Usage: build.sh [white]
+##
+
+
 set -e
+
+rm -rf Options.tex
 
 if [ -d ".git" ]; then
 
 SHA=`git rev-parse --short --verify HEAD`
 DATE=`git show -s --format="%cd" --date=short HEAD`
 REV="$SHA - $DATE"
-
-else
-
-REV="unknown revision"
+echo "\def\YellowPaperVersionNumber{$REV}" >> Options.tex
 
 fi
+
+
+if [ "$1" == "white" ]; then
+
+echo "\definecolor{pagecolor}{rgb}{1,1,1}" >> Options.tex
+
+fi
+
+
 
 echo "\newcommand{\YellowPaperVersionNumber}{$REV}" > Version.tex
 
@@ -21,3 +34,4 @@ bibtex Paper && \
 pdflatex -interaction=errorstopmode -halt-on-error Paper.tex && \
 pdflatex -interaction=errorstopmode -halt-on-error Paper.tex && \
 pdflatex -interaction=errorstopmode -halt-on-error Paper.tex
+rm -rf Options.tex


### PR DESCRIPTION
Adds an option to generate a paper with white background. Fixes #580.

# Usage

```sh
./build.sh                # default yellow
./build.sh white          # makes it white
```

This is documented in the source of build.sh

# Rationale

White background increases readability and reduces ink for printed copies.