### PR TITLE
Remove verifiable computation

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1241,8 +1241,6 @@ Scalability remains an eternal concern. With a generalised state transition func
 
 Some form of hierarchical structure, achieved by either consolidating smaller lighter-weight chains into the main block or building the main block through the incremental combination and adhesion (through proof-of-work) of smaller transaction sets may allow parallelisation of transaction combination and block-building. Parallelism could also come from a prioritised set of parallel blockchains, consolidating each block and with duplicate or invalid transactions thrown out accordingly.
 
-Finally, verifiable computation, if made generally available and efficient enough, may provide a route to allow the proof-of-work to be the verification of final state.
-
 \section{Conclusion} \label{ch:conclusion}
 
 We have introduced, discussed and formally defined the protocol of Ethereum. Through this protocol the reader may implement a node on the Ethereum network and join others in a decentralised secure social operating system. Contracts may be authored in order to algorithmically specify and autonomously enforce rules of interaction.


### PR DESCRIPTION
There was a note about verifiable computing:

> Finally, verifiable computation, if made generally available and efficient enough, may provide a route to allow the proof-of-work to be the verification of final state.

Just to be clear, verifiable computing would completely obviate the need for Ethereum. There is no need to consider other minutiae of how verifiable computing would would impact the then-dead Ethereum project.