### PR TITLE
Corrected constant coefficient of G2

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1576,7 +1576,7 @@ We define $P_1$ to be a point $(1,2)$ on $C_1$. Let $G_1$ be the subgroup of $(C
 
 Let $F_{p^2}$ be a field $F_{\mathrm{p}}[i]/(i+1)$. We define a set $C_2$ with
 \begin{equation}
-C_2\equiv\{(X,Y)\in F_{p^2}\times F_{p^2}\mid Y^2=X^3+3\}\cup\{(0,0)\}
+C_2\equiv\{(X,Y)\in F_{p^2}\times F_{p^2}\mid Y^2=X^3+3(i+9)^{-1}\}\cup\{(0,0)\}
 \end{equation}
 We define a binary operation $+$ and a scalar multiplication $\cdot$ with the same equations (\ref{eq:ec-addition}) and (\ref{eq:ec-scalar-multiplication}). $(C_2,+)$ is also known to be a group. We define $P_2$ in $C_2$ with
 \begin{eqnarray}


### PR DESCRIPTION
Curve for G2 in zkSNARK related precompiled contracts has a slightly different constant coefficient than the curve for G1. Found correct value in [libff](https://github.com/scipr-lab/libff/blob/master/libff/algebra/curves/alt_bn128/alt_bn128_init.cpp#L136)