### PR TITLE
Add \nonumber to lines in elliptic curve group law

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1561,9 +1561,9 @@ We define a binary operation $+$ on $C_1$ for distinct elements $(X_1, Y_1), (X_
 (X,Y)&\text{if}\ X_1\neq X_2\\
 (0,0)&\text{otherwise}
 \end{cases}\\
-\lambda&\equiv&\frac{Y_2-Y_1}{X_2-X_1}\\
-X&\equiv&\lambda^2-X_1-X_2\\
-Y&\equiv&\lambda(X_1-X)-Y_1
+\nonumber \lambda&\equiv&\frac{Y_2-Y_1}{X_2-X_1}\\
+\nonumber X&\equiv&\lambda^2-X_1-X_2\\
+\nonumber Y&\equiv&\lambda(X_1-X)-Y_1
 \end{eqnarray}
 
 In the case where $(X_1, Y_1) = (X_2, Y_2)$, we define $+$ on $C_1$ with
@@ -1572,9 +1572,9 @@ In the case where $(X_1, Y_1) = (X_2, Y_2)$, we define $+$ on $C_1$ with
 (X,Y)&\text{if}\ Y_1\neq 0\\
 (0,0)&\text{otherwise}
 \end{cases}\\
-\lambda&\equiv&\frac{3X_1^2}{2Y_1}\\
-X&\equiv&\lambda^2-2X_1\\
-Y&\equiv&\lambda(X_1-X)-Y_1
+\nonumber \lambda&\equiv&\frac{3X_1^2}{2Y_1}\\
+\nonumber X&\equiv&\lambda^2-2X_1\\
+\nonumber Y&\equiv&\lambda(X_1-X)-Y_1
 \end{eqnarray}
 
 $(C_1,+)$ is known to form a group. We define the scalar multiplication $\cdot$ with


### PR DESCRIPTION
This is added since these are really each just one equation. 