### PR TITLE
Add a missing logical connective in the exceptional halting condition

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -979,8 +979,8 @@ Z(\boldsymbol{\sigma}, \boldsymbol{\mu}, I) \equiv
 ( w = \text{\small JUMPI} \quad \wedge \quad \boldsymbol{\mu}_\mathbf{s}[1] \neq 0 \quad \wedge \\
 \quad \boldsymbol{\mu}_\mathbf{s}[0] \notin D(I_\mathbf{b}) ) \quad \vee \\
 ( w = \text{\small RETURNDATACOPY} \wedge \\ \quad \boldsymbol{\mu}_{\mathbf{s}}[1] + \boldsymbol{\mu}_{\mathbf{s}}[2] > \lVert\boldsymbol{\mu}_{\mathbf{o}}\rVert) \quad \vee \\
-\lVert\boldsymbol{\mu}_\mathbf{s}\rVert - \mathbf{\delta}_w + \mathbf{\alpha}_w > 1024
- \neg I_{\mathrm{w}} \wedge W(w, \boldsymbol{\mu})
+\lVert\boldsymbol{\mu}_\mathbf{s}\rVert - \mathbf{\delta}_w + \mathbf{\alpha}_w > 1024 \vee
+ (\neg I_{\mathrm{w}} \wedge W(w, \boldsymbol{\mu}))
 \end{array}
 \end{equation}
 where


### PR DESCRIPTION
The last clause should be appended with \vee (or \lor)