### PR TITLE
Remove dotted lines from the gas value table

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1770,7 +1770,6 @@ The fee schedule $G$ is a tuple of 31 scalar values corresponding to the relativ
 \toprule
 Name & Value & Description* \\
 \midrule
-\everyrow{\tabucline[on 2pt]-}
 $G_{zero}$ & 0 & Nothing paid for operations of the set {\small $W_{zero}$}. \\
 $G_{base}$ & 2 & Amount of gas to pay for operations of the set {\small $W_{base}$}. \\
 $G_{verylow}$ & 3 & Amount of gas to pay for operations of the set {\small $W_{verylow}$}. \\
@@ -1807,7 +1806,7 @@ $G_{\mathrm{logtopic}}$ & 375 & Paid for each topic of a {\small LOG} operation.
 $G_{sha3}$ & 30 & Paid for each {\small SHA3} operation. \\
 $G_{sha3word}$ & 6 & Paid for each word (rounded up) for input data to a {\small SHA3} operation. \\
 $G_{copy}$ & 3 & Partial payment for {\small *COPY} operations, multiplied by words copied, rounded up. \\
-$G_{blockhash}$ & 20 & Payment for {\small BLOCKHASH} operation. \\ \everyrow{}
+$G_{blockhash}$ & 20 & Payment for {\small BLOCKHASH} operation. \\
 $G_{quaddivisor}$ & 100 & The quadratic coefficient of the input sizes of the exponentiation-over-modulo precompiled\\
 &&contract. \\ 
 


### PR DESCRIPTION
The dotted lines were added at commit https://github.com/ethereum/yellowpaper/commit/80bf4b92d4cac5c53122ec065b10881f9b491e23 but I found them noisy.