### PR TITLE
Correct self-destruct refund semantics

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -643,9 +643,14 @@ and $T_{\mathrm{o}}$ is the original transactor, which can differ from the sende
 
 Note we use $\Theta_{4}$ and $\Lambda_{4}$ to denote the fact that only the first four components of the functions' values are taken; the final represents the message-call's output value (a byte array) and is unused in the context of transaction evaluation.
 
-After the message call or contract creation is processed, the state is finalised by determining the amount to be refunded, $g^*$ from the remaining gas, $g'$, plus some allowance from the refund counter, to the sender at the original rate\footnote{Note that the total refundable gas equation prevents the gas refund from exceeding the transaction gas limit $T_{\mathrm{g}}$.}.
+After the message call or contract creation is processed, the refund counter has to be incremented for the account that were self-destructed throughout its invocation.
 \begin{equation}
-g^* \equiv g' + \min \left\{ \Big\lfloor \dfrac{T_{\mathrm{g}} - g'}{2} \Big\rfloor, \hyperlink{refund_balance_defn_words_A__r}{A_{\mathrm{r}}} \right\}
+	A'_{r} \equiv A_{r} + \sum_{i \in A_{s}} R_{selfdestruct}
+\end{equation}
+
+Then the state is finalised by determining the amount to be refunded, $g^*$ from the remaining gas, $g'$, plus some allowance from the refund counter, to the sender at the original rate.
+\begin{equation}
+g^* \equiv g' + \min \left\{ \Big\lfloor \dfrac{T_{\mathrm{g}} - g'}{2} \Big\rfloor, \hyperlink{refund_balance_defn_words_A__r}{A'_{\mathrm{r}}} \right\}
 \end{equation}
 
 The total refundable amount is the legitimately remaining gas $g'$, added to \hyperlink{refund_balance_defn_words_A__r}{$A_{\mathrm{r}}$}, with the latter component being capped up to a maximum of half (rounded down) of the total amount used $T_{\mathrm{g}} - g'$. Therefore, $g^*$ is the total gas that remains after the transaction has been executed.
@@ -2369,13 +2374,9 @@ G_{newaccount} & \text{if} \quad \mathtt{\tiny DEAD}(\boldsymbol{\sigma}, \bolds
 \varnothing &\text{if}\ \boldsymbol{\sigma}[r] = \varnothing\ \wedge\ \boldsymbol{\sigma}[I_{\mathrm{a}}]_{\mathrm{b}} = 0\\
 (\boldsymbol{\sigma}[r]_{\mathrm{n}}, \boldsymbol{\sigma}[r]_{\mathrm{b}} + \boldsymbol{\sigma}[I_{\mathrm{a}}]_{\mathrm{b}}, \boldsymbol{\sigma}[r]_{\mathbf{s}}, \boldsymbol{\sigma}[r]_{\mathrm{c}}) & \text{if}\ r \neq I_{\mathrm{a}} \\
 (\boldsymbol{\sigma}[r]_{\mathrm{n}}, 0, \boldsymbol{\sigma}[r]_{\mathbf{s}}, \boldsymbol{\sigma}[r]_{\mathrm{c}}) & \text{otherwise}
-\end{cases}$\\
-&&&& where $r = \boldsymbol{\mu}_{\mathbf{s}}[0] \bmod 2^{160}$\\
+\end{cases}$\\ \\
+&&&& where $r = \boldsymbol{\mu}_{\mathbf{s}}[0] \bmod 2^{160}$\\ \\
 &&&& $\boldsymbol{\sigma}'[I_{\mathrm{a}}]_{\mathrm{b}} = 0$ \\
-&&&& $A'_{r} \equiv A_{r} + \begin{cases}
-R_{selfdestruct} & \text{if} \quad I_{\mathrm{a}} \notin A_{\mathbf{s}} \\
-0 & \text{otherwise}
-\end{cases}$ \\
 &&&&\linkdest{C tiny SELFDESTRUCT}{} $C_{\text{\tiny SELFDESTRUCT}}(\boldsymbol{\sigma}, \boldsymbol{\mu}) \equiv G_{selfdestruct} + \begin{cases}
 G_{newaccount} & \text{if} \quad n \\
 0 & \text{otherwise}


### PR DESCRIPTION
The current Yellow Paper specification for the self-destruct refunds can
lead to double refunds and is not consistent with the logic clients use
to fulfill refunds in practice.

The crux of the issue is that the current Yellow Paper performs the
self-destruct refund within the SELFDESTRUCT operation of a specific EVM
invocation and each EVM invocation creates its own transaction substate
(rather than having it passed in from its parent). Therefore, although
the transaction substate is checked to see if the account has already
been included in its self-destruct set, that self-destruct set does not
have complete knowledge of the other self-destructions that have
occurred throughout the entire parent transactions execution so far
(e.g. the ancestor and sibling/nibling/etc). Said another way, the EVM
invocation only knows about the self-destructions that have occurred
through the internal message calls and contract creations chains it has
created and an account self-destructed in that chain may have already
been self-destructed outside the scope of it’s invocation.

The cleanest way to handle this issue, which was done by [cpp-ethereum](https://github.com/ethereum/cpp-ethereum/blob/aea3bc120761fe27fc696d0649ba5ae7a56a7915/libethereum/Executive.cpp#L494)
and [pyethereum](https://github.com/ethereum/pyethereum/blob/32c1ca3ee26b4af5936c04a36d80093df0910a21/ethereum/messages.py#L249) and is reflected in this commit, is to perform the
self-destruct refund accumulation after a transaction’s root message
call or contract creation has completed. At this point, all of the
self-destructs that occur within the transaction have been aggregated,
making it a safe point to calculate this refund. It is worth noting that
[geth](https://github.com/ethereum/go-ethereum/blob/762f3a48a00da02fe58063cb6ce8dc2d08821f15/core/vm/gas_table.go#L406) performs the deduction in the EVM still but incorporates some data
it has added to how it represents world state.