### PR TITLE
Remove "kern 10pc" visible in the PDF

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1155,8 +1155,8 @@ If there are collisions of the beneficiary addresses between ommers and the bloc
 \hypertarget{Gamma}{}We may now define the function, $\Gamma$, that maps a block $B$ to its initiation state:
 \begin{equation}
 \Gamma(B) \equiv \begin{cases}
-\boldsymbol{\sigma}_0 kern 10pc \ \text{if} \quad P(B_{H}) = \varnothing \\
-\boldsymbol{\sigma}_{\mathrm{i}}: \mathtt{\small \hyperlink{trie}{TRIE}}(L_{S}(\boldsymbol{\sigma}_{\mathrm{i}})) = {P(B_{H})_{H}}_{\mathrm{r}} \quad\text{otherwise}
+\boldsymbol{\sigma}_0 & \text{if} \quad P(B_{H}) = \varnothing \\
+\boldsymbol{\sigma}_{\mathrm{i}}: \mathtt{\small \hyperlink{trie}{TRIE}}(L_{S}(\boldsymbol{\sigma}_{\mathrm{i}})) = {P(B_{H})_{H}}_{\mathrm{r}} &\text{otherwise}
 \end{cases}
 \end{equation}
 


### PR DESCRIPTION
A LaTeX formatting command was left visible in the PDF.  Moreover, the formatting command contained some concrete length values that can be easily removed from the source as well.