### PR TITLE
fix: B is defined as a 3-tuple

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -134,7 +134,7 @@ Mining is the process of dedicating effort (working) to bolster one series of tr
 Formally, we expand to:
 \begin{eqnarray}
 \boldsymbol{\sigma}_{t+1} & \equiv & \hyperlink{Pi}{\Pi}(\boldsymbol{\sigma}_{t}, B) \\
-B & \equiv & (..., (T_0, T_1, ...) ) \\
+B & \equiv & (..., (T_0, T_1, ...), ...) \\
 \Pi(\boldsymbol{\sigma}, B) & \equiv & \hyperlink{Omega}{\Omega}(B, \hyperlink{Upsilon}{\Upsilon}(\Upsilon(\boldsymbol{\sigma}, T_0), T_1) ...)
 \end{eqnarray}
 


### PR DESCRIPTION
In section 2, formula `(3)` is redefining the `B` (block) as a `2-tuple`, which is not true according to formula `(19)` in section 4.3, which defines `B` as a `3-tuple`.