### PR TITLE
Fix: Add Block Reward application for pre / post Byzantium and Constantinople cases

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1159,10 +1159,10 @@ If there are collisions of the beneficiary addresses between ommers and the bloc
 
 \hypertarget{block_reward_R__block}{}\linkdest{R__block}We define the block reward in Ether:
 \begin{equation}
-\text{Let} \quad R_{\mathrm{block}} = 3 \times 10^{18}
 \text{Let} \quad R_{\mathrm{block}} = 10^{18} \times \begin{cases}
 5 &\text{if}\ H_{\mathrm{i}} < 4370000 \\
-3 &\text{otherwise}
+3 &\text{if}\ H_{\mathrm{i}} < 7280000 \\
+2 &\text{otherwise}
 \end{cases} \\
 \end{equation}
 

--- a/Paper.tex
+++ b/Paper.tex
@@ -1157,9 +1157,13 @@ R & \equiv & \left(1 + \frac{1}{8} (U_{\mathrm{i}} - {B_{H}}_{\mathrm{i}})\right
 
 If there are collisions of the beneficiary addresses between ommers and the block (i.e. two ommers with the same beneficiary address or an ommer with the same beneficiary address as the present block), additions are applied cumulatively.
 
-\hypertarget{block_reward_R__block}{}\linkdest{R__block}We define the block reward as 2 Ether:
+\hypertarget{block_reward_R__block}{}\linkdest{R__block}We define the block reward in Ether:
 \begin{equation}
-\text{Let} \quad R_{\mathrm{block}} = 2 \times 10^{18}
+\text{Let} \quad R_{\mathrm{block}} = 3 \times 10^{18}
+\text{Let} \quad R_{\mathrm{block}} = 10^{18} \times \begin{cases}
+5 &\text{if}\ H_{\mathrm{i}} < 4370000 \\
+3 &\text{otherwise}
+\end{cases} \\
 \end{equation}
 
 \subsection{State \& Nonce Validation}\label{sec:statenoncevalidation}


### PR DESCRIPTION
Fix the block reward definition, handle both pre / post Byzantium cases and pre / post Constantinople cases.

As an example for Byzantium fork, refer to:
* https://etherscan.io/block/4369999
* https://etherscan.io/block/4370000
* https://etherscan.io/block/4370001

As an example for Constantinople fork, refer to:
* https://etherscan.io/block/7279999
* https://etherscan.io/block/7280000
* https://etherscan.io/block/7080001

Below is depicted visually the change.

![block-reward](https://user-images.githubusercontent.com/1648497/91440989-baba3200-e86f-11ea-92d5-711bf78d9d5c.png)

