### PR TITLE
Fix confusing and irrelevant ECDSA citation

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1694,7 +1694,7 @@ x&\equiv&\delta_1\left(\bar I_{\mathbf{d}}[32..95]\right)
 
 \section{Signing Transactions}\label{app:signing}
 
-The method of signing transactions is similar to the `Electrum style signatures' as defined by \cite{npmElectrum2017}, heading "Managing styles with Radium" in the bullet point list. This method utilises the SECP-256k1 curve as described by \cite{Courtois2014}, and is implemented similarly to as described by \cite{gura2004comparing} on p.~9 of 15, para.~3.
+Transactions are signed using recoverable ECDSA signatures. This method utilises the SECP-256k1 curve as described by \cite{Courtois2014}, and is implemented similarly to as described by \cite{gura2004comparing} on p.~9 of 15, para.~3.
 
 It is assumed that the sender has a valid private key $p_{\mathrm{r}}$, which is a randomly selected positive integer (represented as a byte array of length 32 in big-endian form) in the range \hbox{$[1, \mathtt{secp256k1n} - 1]$}.
 


### PR DESCRIPTION
Fixes part of #704 

Appendix F contains a reference to "Electrum style signatures", but the citation points to a JavaScript frontend library with no mention of ECDSA.