### PR TITLE
Remove last reference to deprecated suicide op

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -915,7 +915,7 @@ The execution model defines the function $\Xi$, which can compute the resultant 
 (\boldsymbol{\sigma}', g', A, \mathbf{o}) \equiv \Xi(\boldsymbol{\sigma}, g, I)
 \end{equation}
 
-where we will remember that $A$, the accrued substate is defined as the tuple of the suicides set $\mathbf{s}$, the log series $\mathbf{l}$, the touched accounts $\mathbf{t}$ and the refunds $r$:
+where we will remember that $A$, the accrued substate is defined as the tuple of the selfdestructs set $\mathbf{s}$, the log series $\mathbf{l}$, the touched accounts $\mathbf{t}$ and the refunds $r$:
 
 \begin{equation}
 A \equiv (\mathbf{s}, \mathbf{l}, \mathbf{t}, r)


### PR DESCRIPTION
# Changelog
## Bug Fixes
* [EIP-6](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-6.md) renamed `SUICIDE` to `SELFDESTRUCT`, but there was still a reference to it, which was confusing as nothing else in the paper explains suicide was the old name for selfdestruct.