### PR TITLE
Change arg max to max in Appendix D.

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1448,7 +1448,7 @@ A branch is then only used when necessary; no branch nodes may exist that contai
 \begin{equation}
 c(\mathfrak{I}, i) \equiv \begin{cases}
 \texttt{RLP}\Big( \big(\texttt{HP}(I_0[i .. (\lVert I_0\rVert - 1)], true), I_1 \big) \Big) & \text{if} \quad \lVert \mathfrak{I} \rVert = 1 \quad \text{where} \; \exists I: I \in \mathfrak{I} \\
-\texttt{RLP}\Big( \big(\texttt{HP}(I_0[i .. (j - 1)], false), n(\mathfrak{I}, j) \big) \Big) & \text{if} \quad i \ne j \quad \text{where} \; j = \arg \max_{x} : \exists \mathbf{l}: \lVert \mathbf{l} \rVert = x : \forall_{I \in \mathfrak{I}}: I_0[0 .. (x - 1)] = \mathbf{l} \\
+\texttt{RLP}\Big( \big(\texttt{HP}(I_0[i .. (j - 1)], false), n(\mathfrak{I}, j) \big) \Big) & \text{if} \quad i \ne j \quad \text{where} \; j = \max \{ x : \exists \mathbf{l}: \lVert \mathbf{l} \rVert = x \wedge \forall_{I \in \mathfrak{I}}: I_0[0 .. (x - 1)] = \mathbf{l} \} \\
 \texttt{RLP}\Big( (u(0), u(1), ..., u(15), v) \Big) & \text{otherwise} \quad \text{where} \begin{array}[t]{rcl}
 u(j) & \equiv & n(\{ I : I \in \mathfrak{I} \wedge I_0[i] = j \}, i + 1) \\
 v & = & \begin{cases}


### PR DESCRIPTION
Here j is the maximum x such that there exists an \mathbf{l} such that etc. etc.
That is, j is the length of the longest common prefix of all the keys (nibble
arrays) of the \mathfrak{I} map.

Note that j is not the argument x that maximizes the value of a function over x.
The expression \exists \mathbf{l} ... following \arg \max is boolean-valued.

Also change a colon into a \wedge, which conjoins the two constraints over x and
\mathbf{l} in the set comprehension.