### PR TITLE
Clarify the definition of RLP trees.

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1325,12 +1325,12 @@ This is a serialisation method for encoding arbitrarily structured binary data (
 
 We define the set of possible structures $\mathbb{T}$:
 \begin{eqnarray}
-\mathbb{T} & \equiv & \mathbb{L} \cup \mathbb{B} \\
+\mathbb{T} & \equiv & \mathbb{L} \uplus \mathbb{B} \\
 \mathbb{L} & \equiv & \{ \mathbf{t}: \mathbf{t} = ( \mathbf{t}[0], \mathbf{t}[1], ... ) \; \wedge \; \forall_{n < \lVert \mathbf{t} \rVert} \; \mathbf{t}[n] \in \mathbb{T} \} \\
 \mathbb{B} & \equiv & \{ \mathbf{b}: \mathbf{b} = ( \mathbf{b}[0], \mathbf{b}[1], ... ) \; \wedge \; \forall_{n < \lVert \mathbf{b} \rVert} \; \mathbf{b}[n] \in \mathbb{O} \}
 \end{eqnarray}
 
-Where $\mathbb{O}$ is the set of (8-bit) bytes. Thus $\mathbb{B}$ is the set of all sequences of bytes (otherwise known as byte-arrays, and a leaf if imagined as a tree), $\mathbb{L}$ is the set of all tree-like (sub-)structures that are not a single leaf (a branch node if imagined as a tree) and $\mathbb{T}$ is the set of all byte-arrays and such structural sequences.
+Where $\mathbb{O}$ is the set of (8-bit) bytes. Thus $\mathbb{B}$ is the set of all sequences of bytes (otherwise known as byte-arrays, and a leaf if imagined as a tree), $\mathbb{L}$ is the set of all tree-like (sub-)structures that are not a single leaf (a branch node if imagined as a tree) and $\mathbb{T}$ is the set of all byte-arrays and such structural sequences. The disjoint union $\uplus$ is needed only to distinguish the empty byte array $()\in\mathbb{B}$ from the empty list $()\in\mathbb{L}$, which are encoded differently as defined below; as common, we will abuse notation and leave the disjoint union indices implicit, inferable from context.
 
 We define the RLP function as $\mathtt{RLP}$ through two sub-functions, the first handling the instance when the value is a byte array, the second when it is a sequence of further values:
 \begin{equation}


### PR DESCRIPTION
According to equations (177) and (178), the empty list is () and the empty byte
array is also (). So, if \mathbb{T} is defined as set union, it would contain a
single empty sequence. But the empty byte array and the empty list are encoded
differently, according to equations (180) and (183) -- as the 128 and as 192,
respectively. So \mathbb{T} must contain separate elements for the empty byte
array and for the empty list, which is achieved via a disjoint union. Non-empty
byte arrays and non-empty lists are inherently distinct, since a byte is a
number.

This changes
![176-before](https://user-images.githubusercontent.com/2409151/56085863-15302b00-5e00-11e9-8f22-43f790b3d7b3.png)
to
![176-after](https://user-images.githubusercontent.com/2409151/56085865-18c3b200-5e00-11e9-8ace-d92238dfe1c5.png)
and also adds
![text](https://user-images.githubusercontent.com/2409151/56085921-dea6e000-5e00-11e9-8bfe-84b20ade8ffe.png)



