### PR TITLE
Fix font and improve wording.

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1383,7 +1383,7 @@ s(\mathbf{x}) & \equiv & \begin{cases}
 \end{cases}
 \end{eqnarray}
 
-If RLP is used to encode a scalar, defined only as a non-negative integer ($\mathbb{N}$ or any $x$ for $\mathbb{N}_{\mathrm{x}}$), it must be specified as the shortest byte array such that the big-endian interpretation of it is equal. Thus the RLP of some non-negative integer $i$ is defined as:
+If RLP is used to encode a scalar, defined only as a non-negative integer (in $\mathbb{N}$, or in $\mathbb{N}_x$ for any $x$), it must be specified as the shortest byte array such that the big-endian interpretation of it is equal. Thus the RLP of some non-negative integer $i$ is defined as:
 \begin{equation}
 \mathtt{RLP}(i : i \in \mathbb{N}) \equiv \mathtt{RLP}(\mathtt{BE}(i))
 \end{equation}


### PR DESCRIPTION
The \mathrm{x} used as subscript to \mathbb{N} was not matching the plain
(\mathit) x in the phrase.

The wording was also not very clear. The new wording should be better.

This changes
![old](https://user-images.githubusercontent.com/2409151/56995859-cc92a480-6b57-11e9-81b7-dea5cbbd2978.png)
to
![new](https://user-images.githubusercontent.com/2409151/56995880-da482a00-6b57-11e9-9f79-fa99b4ebcc9b.png)

