### PR TITLE
Fix notation for sequence elements.

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1378,7 +1378,7 @@ R_{\mathrm{l}}(\mathbf{x}) & \equiv & \begin{cases}
 \varnothing & \text{otherwise}
 \end{cases} \\
 s(\mathbf{x}) & \equiv & \begin{cases}
-\mathtt{RLP}(\mathbf{x}_0) \cdot \mathtt{RLP}(\mathbf{x}_1) \cdot ... & \text{if} \quad \forall i: \mathtt{RLP}(\mathbf{x}_i) \neq \varnothing \\
+\mathtt{RLP}(\mathbf{x}[0]) \cdot \mathtt{RLP}(\mathbf{x}[1]) \cdot ... & \text{if} \quad \forall i: \mathtt{RLP}(\mathbf{x}[i]) \neq \varnothing \\
 \varnothing & \text{otherwise}
 \end{cases}
 \end{eqnarray}


### PR DESCRIPTION
According to eqs. (177) and (178), the elements of the sequence are selected
with the notation ...[...]. While eq. (180) uses that notation for x[0],
eq. (184) was using a subscript notation x_0, x_1, and x_i. This commit turns
these into x[0], x[1], and x[i].

This changes
![old](https://user-images.githubusercontent.com/2409151/56855779-11250280-6902-11e9-8358-5f7c525ce046.png)
to
![new](https://user-images.githubusercontent.com/2409151/56855781-15512000-6902-11e9-9506-5cac6675b4b5.png)
