### PR TITLE
Improve summation notation in BE definition.

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1355,7 +1355,7 @@ R_{\mathrm{b}}(\mathbf{x}) & \equiv & \begin{cases}
 \big(183 + \big\lVert \mathtt{BE}(\lVert \mathbf{x} \rVert) \big\rVert \big) \cdot \mathtt{BE}(\lVert \mathbf{x} \rVert) \cdot \mathbf{x} & \text{else if} \quad \lVert \mathbf{x} \rVert < 2^{64} \\
 \varnothing & \text{otherwise}
 \end{cases} \\
-\mathtt{BE}(x) & \equiv & (b_0, b_1, ...): b_0 \neq 0 \wedge x = \sum_{n = 0}^{n < \lVert \mathbf{b} \rVert} b_n \cdot 256^{\lVert \mathbf{b} \rVert - 1 - n} \\
+\mathtt{BE}(x) & \equiv & (b_0, b_1, ...): b_0 \neq 0 \wedge x = \sum_{n = 0}^{\lVert \mathbf{b} \rVert - 1} b_n \cdot 256^{\lVert \mathbf{b} \rVert - 1 - n} \\
 (a) \cdot (b, c) \cdot (d, e) & = & (a, b, c, d, e)
 \end{eqnarray}
 


### PR DESCRIPTION
This changes
![old](https://user-images.githubusercontent.com/2409151/56917270-eeb0f780-6a6f-11e9-9f6e-9b21ef453f1e.png)
to
![new](https://user-images.githubusercontent.com/2409151/56917285-f83a5f80-6a6f-11e9-80eb-196581833671.png)

Summation normally has one of the following forms:

\sum_{index=min}^{index=max}  -- for index varying from min to max
\sum_{index=min}^{max}  -- same as above
\sum_{P{index)}  -- for indices varying over the values that satisfy P

Also see https://en.wikipedia.org/wiki/Summation

The summation in the definition of the function BE in eq. (181) was "mixing"
different forms. The new one uses the second form above, which is also used in
eq. (320).
