### PR TITLE
Treat t argument of HP (and f) as boolean.

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1404,7 +1404,7 @@ It is defined as the function $\mathtt{HP}$ which maps from a sequence of nibble
 (16(f(t) + 1) + \mathbf{x}[0], 16\mathbf{x}[1] + \mathbf{x}[2], 16\mathbf{x}[3] + \mathbf{x}[4], ...) &
 \text{otherwise}
 \end{cases} \\
-f(t) & \equiv & \begin{cases} 2 & \text{if} \quad t \neq 0 \\ 0 & \text{otherwise} \end{cases}
+f(t) & \equiv & \begin{cases} 2 & \text{if} \quad t = \mathit{true} \\ 0 & \text{otherwise} \end{cases}
 \end{eqnarray}
 
 Thus the high nibble of the first byte contains two flags; the lowest bit encoding the oddness of the length and the second-lowest encoding the flag $t$. The low nibble of the first byte is zero in the case of an even number of nibbles and the first nibble in the case of an odd number. All remaining nibbles (now an even number) fit properly into the remaining bytes.


### PR DESCRIPTION
The paragraph just before eq. (186) says that the second argument, t, of the
function HP, is a boolean value. The function HP is passed the boolean values
true and false as t in eq. (194). However, eq. (187) was treating t as a number,
in the condition 't \neq 0'. Even though booleans are isomorphic to {0, 1}, it's
clearer to change that condition to 't = true'.

This changes
![old-hp-bool](https://user-images.githubusercontent.com/2409151/57258379-19232780-7011-11e9-942c-cde254c47f16.png)
to
![new-hp-bool](https://user-images.githubusercontent.com/2409151/57258386-1de7db80-7011-11e9-9af7-d7a2678c1331.png)

Unless there are objections, I'll merge in a few days.
