### PR TITLE
Fix mathematical symbols (17 modifications).

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1013,7 +1013,7 @@ D(\mathbf{c}) \equiv D_{J}(\mathbf{c}, 0)
 where:
 \begin{equation}
 D_{J}(\mathbf{c}, i) \equiv \begin{cases}
-\{\} & \text{if} \quad i \geqslant |\mathbf{c}|  \\
+\{\} & \text{if} \quad i \geqslant \lVert \mathbf{c} \rVert  \\
 \{ i \} \cup D_{J}(\mathbf{c}, N(i, \mathbf{c}[i])) & \\
 \quad\quad\text{if} \quad \mathbf{c}[i] = \text{\small JUMPDEST} \\
 D_{J}(\mathbf{c}, N(i, \mathbf{c}[i])) & \text{otherwise} \\
@@ -1489,12 +1489,12 @@ We define $\Xi_{\mathtt{ECREC}}$ as a precompiled contract for the elliptic curv
 \begin{eqnarray}
 \Xi_{\mathtt{ECREC}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{where:} \\
 g_{\mathrm{r}} &=& 3000\\
-|\mathbf{o}| &=& \begin{cases} 0 & \text{if} \quad \mathtt{ECDSARECOVER}(h, v, r, s) = \varnothing\\ 32 & \text{otherwise} \end{cases}\\
-\text{if} \quad |\mathbf{o}| = 32: &&\\
+\lVert \mathbf{o} \rVert &=& \begin{cases} 0 & \text{if} \quad \mathtt{ECDSARECOVER}(h, v, r, s) = \varnothing\\ 32 & \text{otherwise} \end{cases}\\
+\text{if} \quad \lVert \mathbf{o} \rVert = 32: &&\\
 \mathbf{o}[0..11] &=& 0 \\
 \mathbf{o}[12..31] &=& \mathtt{KEC}\big(\mathtt{ECDSARECOVER}(h, v, r, s)\big)[12..31] \quad \text{where:}\\
-\mathbf{d}[0..(|\hyperlink{I__d}{I_{\mathbf{d}}}|-1)] &=& I_{\mathbf{d}}\\
-\mathbf{d}[|I_{\mathbf{d}}|..] &=& (0, 0, ...) \\
+\mathbf{d}[0..(\lVert \hyperlink{I__d}{I_{\mathbf{d}}} \rVert-1)] &=& I_{\mathbf{d}}\\
+\mathbf{d}[\lVert I_{\mathbf{d}} \rVert..] &=& (0, 0, ...) \\
 h &=& \mathbf{d}[0..31]\\
 v &=& \mathbf{d}[32..63]\\
 r &=& \mathbf{d}[64..95]\\
@@ -1505,10 +1505,10 @@ We define $\Xi_{\mathtt{SHA256}}$ and $\Xi_{\mathtt{RIP160}}$ as precompiled con
 
 \begin{eqnarray}
 \Xi_{\mathtt{SHA256}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{where:} \\
-g_{\mathrm{r}} &=& 60 + 12\Big\lceil \dfrac{|I_{\mathbf{d}}|}{32} \Big\rceil\\
+g_{\mathrm{r}} &=& 60 + 12\Big\lceil \dfrac{\lVert I_{\mathbf{d}} \rVert}{32} \Big\rceil\\
 \mathbf{o}[0..31] &=& \mathtt{SHA256}(I_{\mathbf{d}})\\
 \Xi_{\mathtt{RIP160}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{where:} \\
-g_{\mathrm{r}} &=& 600 + 120\Big\lceil \dfrac{|I_{\mathbf{d}}|}{32} \Big\rceil\\
+g_{\mathrm{r}} &=& 600 + 120\Big\lceil \dfrac{\lVert I_{\mathbf{d}} \rVert}{32} \Big\rceil\\
 \mathbf{o}[0..11] &=& 0 \\
 \mathbf{o}[12..31] &=& \mathtt{RIPEMD160}(I_{\mathbf{d}})
 \end{eqnarray}
@@ -1523,7 +1523,7 @@ For the purposes here, we assume we have well-defined standard cryptographic fun
 The fourth contract, the identity function $\Xi_{\mathtt{ID}}$ simply defines the output as the input:
 \begin{eqnarray}
 \Xi_{\mathtt{ID}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{where:} \\
-g_{\mathrm{r}} &=& 15 + 3\Big\lceil \dfrac{|I_{\mathbf{d}}|}{32} \Big\rceil\\
+g_{\mathrm{r}} &=& 15 + 3\Big\lceil \dfrac{\lVert I_{\mathbf{d}} \rVert}{32} \Big\rceil\\
 \mathbf{o} &=& I_{\mathbf{d}}
 \end{eqnarray}
 
@@ -1551,7 +1551,7 @@ B &\equiv& i[96..(95+\ell_{B})] \\
 E &\equiv& i[(96+\ell_{B})..(95+\ell_{B}+\ell_{E})] \\
 M &\equiv& i[(96+\ell_{B}+\ell_{E})..(95+\ell_{B}+\ell_{E}+\ell_{M})] \\
 i[x] &\equiv& \begin{cases}
-I_{\mathbf{d}}[x] &\text{if}\ x < |I_{\mathbf{d}}| \\
+I_{\mathbf{d}}[x] &\text{if}\ x < \lVert I_{\mathbf{d}} \rVert \\
 0 &\text{otherwise}
 \end{cases}
 \end{eqnarray}
@@ -1661,8 +1661,8 @@ We define $\Xi_{\mathtt{SNARKV}}$ as a precompiled contract which checks if (\re
 \begin{eqnarray}
 \Xi_{\mathtt{SNARKV}}&\equiv&\Xi_{\mathtt{PRE}}\quad\text{except:}\\
 \qquad\Xi_{\mathtt{SNARKV}}(\boldsymbol\sigma,g,I)&=&\left(\varnothing,0,A^0,()\right)\quad\text{if}\ F\\
-F&\equiv&(|I_{\mathbf{d}}|\bmod 192\neq 0\vee(\exists j.\ a_{\mathrm{j}}=\varnothing\vee b_{\mathrm{j}}=\varnothing))\\
-k &=& \dfrac{|I_{\mathbf{d}}|}{192} \\
+F&\equiv&(\lVert I_{\mathbf{d}} \rVert\bmod 192\neq 0\vee(\exists j.\ a_{\mathrm{j}}=\varnothing\vee b_{\mathrm{j}}=\varnothing))\\
+k &=& \dfrac{\lVert I_{\mathbf{d}} \rVert}{192} \\
 g_{\mathrm{r}}&=& 80000k + 100000 \\
 \mathbf{o}[0..31]&\equiv&\begin{cases}
 0x0000000000000000000000000000000000000000000000000000000000000001&\text{if}\ v\wedge\neg F\\
@@ -1672,8 +1672,8 @@ v&\equiv&(\log_{P_1}(a_1)\times\log_{P_2}(b_1)+\cdots+\log_{P_1}(a_k)\times\log_
 a_1&\equiv&\delta_1(I_{\mathbf{d}}[0..63])\\
 b_1&\equiv&\delta_2(I_{\mathbf{d}}[64..191])\\\nonumber
 \vdots\\
-a_k&\equiv&\delta_1(I_{\mathbf{d}}[(|I_{\mathbf{d}}|-192)..(|I_{\mathbf{d}}|-129)])\\
-b_k&\equiv&\delta_2(I_{\mathbf{d}}[(|I_{\mathbf{d}}|-128)..(|I_{\mathbf{d}}|-1)])
+a_k&\equiv&\delta_1(I_{\mathbf{d}}[(\lVert I_{\mathbf{d}} \rVert-192)..(\lVert I_{\mathbf{d}} \rVert-129)])\\
+b_k&\equiv&\delta_2(I_{\mathbf{d}}[(\lVert I_{\mathbf{d}} \rVert-128)..(\lVert I_{\mathbf{d}} \rVert-1)])
 \end{eqnarray}
 
 We define a precompiled contract for addition on $G_1$.
@@ -1686,7 +1686,7 @@ g_{\mathrm{r}} &=& 500\\
 x&\equiv&\delta_1\left(\bar I_{\mathbf{d}}[0..63]\right)\\
 y&\equiv&\delta_1\left(\bar I_{\mathbf{d}}[64..127]\right)\\
 \label{eq:complemented_input}\bar I_{\mathbf{d}}[x]&\equiv&\begin{cases}
-I_{\mathbf{d}}[x]&\text{if}\ x < |I_{\mathbf{d}}|\\
+I_{\mathbf{d}}[x]&\text{if}\ x < \lVert I_{\mathbf{d}} \rVert\\
 0&\text{otherwise}
 \end{cases}
 \end{eqnarray}
@@ -2304,7 +2304,7 @@ R_{sclear} & \text{if} \quad \boldsymbol{\mu}_{\mathbf{s}}[1] = 0 \; \wedge \; \
 0xf1 & {\small CALL} & 7 & 1 & Message-call into an account. \\
 &&&& $\mathbf{i} \equiv \boldsymbol{\mu}_{\mathbf{m}}[ \boldsymbol{\mu}_{\mathbf{s}}[3] \dots (\boldsymbol{\mu}_{\mathbf{s}}[3] + \boldsymbol{\mu}_{\mathbf{s}}[4] - 1) ]$ \\
 &&&& $(\boldsymbol{\sigma}', g', A^+, \mathbf{o}) \equiv \begin{cases}\begin{array}{l}\Theta(\boldsymbol{\sigma}, I_{\mathrm{a}}, I_{\mathrm{o}}, t, t, C_{\text{\tiny CALLGAS}}(\boldsymbol{\mu}),\\ \quad I_{\mathrm{p}}, \boldsymbol{\mu}_{\mathbf{s}}[2], \boldsymbol{\mu}_{\mathbf{s}}[2], \mathbf{i}, I_{\mathrm{e}} + 1, I_{\mathrm{w}})\end{array} & \begin{array}{l}\text{if} \quad \boldsymbol{\mu}_{\mathbf{s}}[2] \leqslant \boldsymbol{\sigma}[I_{\mathrm{a}}]_{\mathrm{b}} \;\wedge \\ \quad\quad I_{\mathrm{e}} < 1024\end{array}\\ (\boldsymbol{\sigma}, g, \varnothing, ()) & \text{otherwise} \end{cases}$ \\
-&&&& $n \equiv \min(\{ \boldsymbol{\mu}_{\mathbf{s}}[6], |\mathbf{o}|\})$ \\
+&&&& $n \equiv \min(\{ \boldsymbol{\mu}_{\mathbf{s}}[6], \lVert \mathbf{o} \rVert\})$ \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{m}}[ \boldsymbol{\mu}_{\mathbf{s}}[5] \dots (\boldsymbol{\mu}_{\mathbf{s}}[5] + n - 1) ] = \mathbf{o}[0 \dots (n - 1)]$ \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{o}} = \mathbf{o}$ \\
 &&&& $\boldsymbol{\mu}'_{\mathrm{g}} \equiv \boldsymbol{\mu}_{\mathrm{g}} + g'$ \\


### PR DESCRIPTION
These variables (**c**, **o**,  **I**_d_) are all arrays. The intention here is to get the length of the array, so apply the norm symbol ( || ) instead of the absolute value symbol ( | ).
The modified content includes the following formulas: 140, 198, 199, 202, 203, 209, 212, 218, 231, 255, 256, 262, 263, 270. And a partial description of the CALL instruction in the appendix "Virtual Machine Specification".

1. In the 140 formula, **c** is the code array, this commit changes
![image](https://user-images.githubusercontent.com/4555304/63163614-77bc6080-c058-11e9-8eb1-f92c7482af55.png)
to
![image](https://user-images.githubusercontent.com/4555304/63163636-89056d00-c058-11e9-88e2-f05ecd1d60de.png)

2. In the 198 and 199 formulas, **o** is the output data, this commit changes(2 modifications)
![image](https://user-images.githubusercontent.com/4555304/63163732-dda8e800-c058-11e9-8c2a-7a085173727c.png)
to
![image](https://user-images.githubusercontent.com/4555304/63163759-ebf70400-c058-11e9-9b04-0f0804766219.png)

3. **I**_d_ , the byte array that is the input data to this execution,  this commit changes(13 modifications)
![image](https://user-images.githubusercontent.com/4555304/63163778-fe713d80-c058-11e9-9f9d-9694745afd33.png)
to
![image](https://user-images.githubusercontent.com/4555304/63163792-0a5cff80-c059-11e9-8ceb-6856512a104c.png)
and also
![image](https://user-images.githubusercontent.com/4555304/63166054-d2a58600-c05f-11e9-9728-66b56f1e9e81.png)
to
![image](https://user-images.githubusercontent.com/4555304/63166074-e224cf00-c05f-11e9-999f-5036a93e7525.png)
and also
![image](https://user-images.githubusercontent.com/4555304/63163839-282a6480-c059-11e9-93ce-7628c0d199f5.png)
to
![image](https://user-images.githubusercontent.com/4555304/63163848-324c6300-c059-11e9-8e33-3744a6d436c7.png)
and also
![image](https://user-images.githubusercontent.com/4555304/63163863-3c6e6180-c059-11e9-9e31-cf22729745d3.png)
to
![image](https://user-images.githubusercontent.com/4555304/63163890-46906000-c059-11e9-9a07-6a226f667aa3.png)
and also
![image](https://user-images.githubusercontent.com/4555304/63163917-5a3bc680-c059-11e9-9ae1-87d4af978b23.png)
to
![image](https://user-images.githubusercontent.com/4555304/63163923-6031a780-c059-11e9-9801-f384e1ef9e67.png)
and also
![image](https://user-images.githubusercontent.com/4555304/63163945-72abe100-c059-11e9-90ad-cf7a86551eb3.png)
to
![image](https://user-images.githubusercontent.com/4555304/63163967-7dff0c80-c059-11e9-8cc8-8d449f77b938.png)
and also
![image](https://user-images.githubusercontent.com/4555304/63163991-8eaf8280-c059-11e9-83ec-01647bf76644.png)
to
![image](https://user-images.githubusercontent.com/4555304/63163996-95d69080-c059-11e9-87c5-b7679ebd4e70.png)
and also
![image](https://user-images.githubusercontent.com/4555304/63164005-a129bc00-c059-11e9-9fc2-5205fddc16e3.png)
to
![image](https://user-images.githubusercontent.com/4555304/63164014-a850ca00-c059-11e9-8366-0295a3b14e81.png)
4. In the CALL instruction description, **o** is the output data, this commit changes
![image](https://user-images.githubusercontent.com/4555304/63164049-c0c0e480-c059-11e9-870b-35faeb3fc92b.png)
to
![image](https://user-images.githubusercontent.com/4555304/63164071-d209f100-c059-11e9-994b-6a1fe35e7231.png)