### PR TITLE
Improve spec of MLOAD, MSTORE, and MSIZE.

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -2146,12 +2146,12 @@ Here given are the various exceptions to the state transition rules given in sec
 \midrule
 0x51 & {\small MLOAD} & 1 & 1 & Load word from memory. \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv \boldsymbol{\mu}_{\mathbf{m}}[\boldsymbol{\mu}_{\mathbf{s}}[0] \dots (\boldsymbol{\mu}_{\mathbf{s}}[0] + 31) ]$ \\
-&&&& $\boldsymbol{\mu}'_{\mathrm{i}} \equiv \max(\boldsymbol{\mu}_{\mathrm{i}}, \ceil{ (\boldsymbol{\mu}_{\mathbf{s}}[0] + 32) \div 32 })$ \\
+&&&& $\boldsymbol{\mu}'_{\mathrm{i}} \equiv \max(\boldsymbol{\mu}_{\mathrm{i}}, \ceil{ (\min(\boldsymbol{\mu}_{\mathbf{s}}[0] + 32, 2^{256}) \div 32 })$ \\
 &&&& The addition in the calculation of $\boldsymbol{\mu}'_{\mathrm{i}}$ is not subject to the $2^{256}$ modulo. \\
 \midrule
 0x52 & {\small MSTORE} & 2 & 0 & Save word to memory. \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{m}}[ \boldsymbol{\mu}_{\mathbf{s}}[0] \dots (\boldsymbol{\mu}_{\mathbf{s}}[0] + 31) ] \equiv \boldsymbol{\mu}_{\mathbf{s}}[1]$ \\
-&&&& $\boldsymbol{\mu}'_{\mathrm{i}} \equiv \max(\boldsymbol{\mu}_{\mathrm{i}}, \ceil{ (\boldsymbol{\mu}_{\mathbf{s}}[0] + 32) \div 32 })$ \\
+&&&& $\boldsymbol{\mu}'_{\mathrm{i}} \equiv \max(\boldsymbol{\mu}_{\mathrm{i}}, \ceil{ (\min(\boldsymbol{\mu}_{\mathbf{s}}[0] + 32, 2^{256}) \div 32 })$ \\
 &&&& The addition in the calculation of $\boldsymbol{\mu}'_{\mathrm{i}}$ is not subject to the $2^{256}$ modulo. \\
 \midrule
 0x53 & {\small MSTORE8} & 2 & 0 & Save byte to memory. \\
@@ -2186,7 +2186,7 @@ R_{sclear} & \text{if} \quad \boldsymbol{\mu}_{\mathbf{s}}[1] = 0 \; \wedge \; \
 &&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv \boldsymbol{\mu}_{\mathrm{pc}}$ \\
 \midrule
 0x59 & {\small MSIZE} & 0 & 1 & Get the size of active memory in bytes. \\
-&&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv 32\boldsymbol{\mu}_{i}$ \\
+&&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv \begin{cases} 32\boldsymbol{\mu}_{i} & \text{if} \quad \boldsymbol{\mu}_{i} < 2^{251} \\ 2^{251}-1 & \text{otherwise} \end{cases}$ \\
 \midrule
 0x5a & {\small GAS} & 0 & 1 & Get the amount of available gas, including the corresponding reduction \\
 &&&& for the cost of this instruction. \\


### PR DESCRIPTION
This is in reference to Issue #767, which has all the relevant discussion.

This changes
<img width="904" alt="old-mload-mstore" src="https://user-images.githubusercontent.com/2409151/83678530-be049100-a592-11ea-9659-33ff382dbd2d.png">
and
<img width="899" alt="old-msize" src="https://user-images.githubusercontent.com/2409151/83678559-c8268f80-a592-11ea-9b3a-98dd2284f82f.png">
to
<img width="877" alt="new-mload-mstore" src="https://user-images.githubusercontent.com/2409151/83678566-cbba1680-a592-11ea-9cff-46908a2859d5.png">
and
<img width="870" alt="new-msize" src="https://user-images.githubusercontent.com/2409151/83678570-ceb50700-a592-11ea-9c1c-76f45858d026.png">
