### PR TITLE
Fix hyperlink

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1179,7 +1179,7 @@ Here, $\mathtt{TRIE}(L_{S}(\boldsymbol{\sigma}_{\mathrm{i}}))$ means the hash of
 \Phi(B) & \equiv & B': \quad B' = B^* \quad \text{except:} \\
 B'_{\mathrm{n}} & = & n: \quad x \leqslant \frac{2^{256}}{\hyperlink{H__d}{H_{\mathrm{d}}}} \\
 B'_{\mathrm{m}} & = & m \quad \text{with } (x, m) = \mathtt{PoW}(B^*_{\hyperlink{H_cancel_n}{\hcancel{n}}}, n, \mathbf{d}) \\
-B^* & \equiv & B \quad \text{except:} \quad {\hyperlink{Transaction Receipt}{B^*_{\mathrm{r}}}} = \hyperlink{r}{r}(\hyperlink{Pi}{\Pi}(\Gamma(B), B))
+B^* & \equiv & B \quad \text{except:} \quad {\hyperlink{Transaction_Receipt}{B^*_{\mathrm{r}}}} = \hyperlink{r}{r}(\hyperlink{Pi}{\Pi}(\Gamma(B), B))
 \end{eqnarray}
 
 With $\mathbf{d}$ being a dataset as specified in appendix \ref{app:ethash}.


### PR DESCRIPTION
Hello. The transaction receipt hyperlink is "Transaction_Receipt", not "Transaction Receipt" :)

By the way, the hyperlink "Upsilon_pow_g2" also doesn't exist and warns. I don't know if this is normal, so I haven't fixed it in this pull request.