### PR TITLE
Update transaction data gas cost for EIP 2028

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1825,7 +1825,7 @@ $G_{expbyte}$ & 50 & Partial payment when multiplied by $\lceil\log_{256}(expone
 $G_{memory}$ & 3 & Paid for every additional word when expanding memory. \\
 \linkdest{G__txcreate}{}$G_\text{txcreate}$ & 32000 & Paid by all contract-creating transactions after the {\textit{Homestead} transition}.\\
 \linkdest{G__txdatazero}{}$G_{txdatazero}$ & 4 & Paid for every zero byte of data or code for a transaction. \\
-\linkdest{G__txdatanonzero}{}$G_{txdatanonzero}$ & 68 & Paid for every non-zero byte of data or code for a transaction. \\
+\linkdest{G__txdatanonzero}{}$G_{txdatanonzero}$ & 16 & Paid for every non-zero byte of data or code for a transaction. \\
 \linkdest{G__transaction}{}$G_{transaction}$ & 21000 & Paid for every transaction. \\
 $G_{\mathrm{log}}$ & 375 & Partial payment for a {\small LOG} operation. \\
 $G_{\mathrm{logdata}}$ & 8 & Paid for each byte in a {\small LOG} operation's data. \\


### PR DESCRIPTION
See [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028).  This change was released in Istanbul.