### PR TITLE
fix: Update SLOAD, BALANCE, and EXTCODEHASH costs after EIP-1884

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1807,9 +1807,9 @@ $G_{\mathrm{low}}$ & 5 & Amount of gas to pay for operations of the set {\small 
 $G_{mid}$ & 8 & Amount of gas to pay for operations of the set {\small $W_{mid}$}. \\
 $G_{\mathrm{high}}$ & 10 & Amount of gas to pay for operations of the set {\small $W_{\mathrm{high}}$}. \\
 $G_{extcode}$ & 700 & Amount of gas to pay for an {\small EXTCODESIZE} operation. \\
-$G_{extcodehash}$ & 400 & Amount of gas to pay for an {\small EXTCODEHASH} operation. \\
-$G_{balance}$ & 400 & Amount of gas to pay for a {\small BALANCE} operation. \\
-$G_{sload}$ & 200 & Paid for a {\small SLOAD} operation. \\
+$G_{extcodehash}$ & 700 & Amount of gas to pay for an {\small EXTCODEHASH} operation. \\
+$G_{balance}$ & 700 & Amount of gas to pay for a {\small BALANCE} operation. \\
+$G_{sload}$ & 800 & Paid for a {\small SLOAD} operation. \\
 $G_{jumpdest}$ & 1 & Paid for a {\small JUMPDEST} operation. \\
 $G_{sset}$ & 20000 & Paid for an {\small SSTORE} operation when the storage value is set to non-zero from zero. \\
 $G_{sreset}$ & 5000 & Paid for an {\small SSTORE} operation when the storage value's zeroness remains unchanged or\\


### PR DESCRIPTION
EIP-1884 updated the cost of SLOAD, BALANCE, and EXTCODEHASH. There [has been confusion](https://ethereum.stackexchange.com/a/91199/44893) about the discrepancy between client implementation and yellow paper.

This PR fixes these values.