### PR TITLE
Amend EXP gas cost inconsistency

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1882,7 +1882,7 @@ $G_{callvalue}$ & 9000 & Paid for a non-zero value transfer as part of the {\sma
 \linkdest{G__callstipend}{}$G_{callstipend}$ & 2300 & A stipend for the called contract subtracted from $G_{callvalue}$ for a non-zero value transfer. \\
 \linkdest{G__newaccount}{}$G_{newaccount}$ & 25000 & Paid for a {\small CALL} or {\small SELFDESTRUCT} operation which creates an account. \\
 $G_{exp}$ & 10 & Partial payment for an {\small EXP} operation. \\
-$G_{expbyte}$ & 50 & Partial payment when multiplied by $\lceil\log_{256}(exponent)\rceil$ for the {\small EXP} operation. \\
+$G_{expbyte}$ & 50 & Partial payment when multiplied by the number of bytes in the $exponent$ for the {\small EXP} operation. \\
 $G_{memory}$ & 3 & Paid for every additional word when expanding memory. \\
 \linkdest{G__txcreate}{}$G_\text{txcreate}$ & 32000 & Paid by all contract-creating transactions after the {\textit{Homestead} transition}.\\
 \linkdest{G__txdatazero}{}$G_{txdatazero}$ & 4 & Paid for every zero byte of data or code for a transaction. \\


### PR DESCRIPTION
There is an inconsistency in how the gas cost of the EXP opcode is explained:

![image](https://user-images.githubusercontent.com/417134/111223307-be1ecc00-85bb-11eb-8ed9-a5e1db9d8fd3.png)

![image](https://user-images.githubusercontent.com/417134/111223324-c119bc80-85bb-11eb-8220-593376cd5fb7.png)

The first one uses a `ceil` while the second one uses a `floor`. I *think* the ceil one is the correct one (or at least that seems to be what `ethereumjs-vm` does). But in any case, they should be the same in both lines.