### PR TITLE
update nonbinary.miraheze.org url

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -326,7 +326,7 @@ T_{\mathbf{t}} \in \begin{cases} \mathbb{B}_{20} & \text{if} \quad T_{\mathrm{t}
 
 \subsection{The Block}\linkdest{block}\label{subsec:The_Block}
 
-The block in Ethereum is the collection of relevant pieces of information (known as the block \textit{header}), $H$, together with information corresponding to the comprised transactions, $\mathbf{T}$,\hypertarget{ommerheaders}{} and a set of other block headers $\mathbf{U}$ that are known to have a parent equal to the present block's parent's parent (such blocks are known as \textit{ommers}\footnote{\textit{ommer} is a gender-neutral term to mean ``sibling of parent''; see \url{https://nonbinary.miraheze.org/wiki/Gender_neutral_language\#Aunt.2FUncle}}). The block header contains several pieces of information:
+The block in Ethereum is the collection of relevant pieces of information (known as the block \textit{header}), $H$, together with information corresponding to the comprised transactions, $\mathbf{T}$,\hypertarget{ommerheaders}{} and a set of other block headers $\mathbf{U}$ that are known to have a parent equal to the present block's parent's parent (such blocks are known as \textit{ommers}\footnote{\textit{ommer} is a gender-neutral term to mean ``sibling of parent''; see \url{https://nonbinary.miraheze.org/wiki/Gender_neutral_language_in_English\#Aunt/Uncle}}). The block header contains several pieces of information:
 
 %\textit{TODO: Introduce logs}
 


### PR DESCRIPTION
The link with the footnote regarding `ommer` is broken, probably due to a change in https://ninbinary.miraheze.org.
I fixed the link to a currently working one.
An even better option would be using the internet archive link: https://web.archive.org/web/20201210120021/https://nonbinary.miraheze.org/wiki/Gender_neutral_language_in_English#Aunt.2FUncle - I'm happy to make that change if that is preferred.