### PR TITLE
Fix off-by-one error in BLOCKHASH domain specification

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -2151,25 +2151,25 @@ Here given are the various exceptions to the state transition rules given in sec
 0x40 & {\small BLOCKHASH} & 1 & 1 & Get the hash of one of the 256 most recent complete blocks. \\
 \linkdest{blockhash}{}&&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv P(I_{\mathbf{H}_{\mathrm{p}}}, \boldsymbol{\mu}_{\mathbf{s}}[0], 0)$ \\
 &&&& where $P$ is the hash of a block of a particular number, up to a maximum\\
-&&&& age. 0 is left on the stack if the looked for block number is greater than\\
-&&&& the current block number or more than 256 blocks behind the current block.\\
+&&&& age. 0 is left on the stack if the looked for block number is greater than or\\
+&&&& equal to the current block number or more than 256 blocks behind the current block.\\
 &&&& $P(h, n, a) \equiv \begin{cases} 0 & \text{if} \quad n > H_{\mathrm{i}} \vee a = 256 \vee h = 0 \\ h & \text{if} \quad n = H_{\mathrm{i}} \\ P(H_{\mathrm{p}}, n, a + 1) & \text{otherwise} \end{cases}$ \\
 &&&& and we assert the header $H$ can be determined from its hash~$h$ unless $h$ is zero\\
 &&&& (as is the case for the parent hash of the genesis block).\\
 \midrule
-0x41 & {\small COINBASE} & 0 & 1 & Get the block's beneficiary address. \\
+0x41 & {\small COINBASE} & 0 & 1 & Get the current block's beneficiary address. \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv {I_{H}}_{\mathrm{c}}$ \\
 \midrule
-0x42 & {\small TIMESTAMP} & 0 & 1 & Get the block's timestamp. \\
+0x42 & {\small TIMESTAMP} & 0 & 1 & Get the current block's timestamp. \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv {I_{H}}_{\mathrm{s}}$ \\
 \midrule
-0x43 & {\small NUMBER} & 0 & 1 & Get the block's number. \\
+0x43 & {\small NUMBER} & 0 & 1 & Get the current block's number. \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv {I_{H}}_{\mathrm{i}}$ \\
 \midrule
-0x44 & {\small DIFFICULTY} & 0 & 1 & Get the block's difficulty. \\
+0x44 & {\small DIFFICULTY} & 0 & 1 & Get the current block's difficulty. \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv {I_{H}}_{\mathrm{d}}$ \\
 \midrule
-0x45 & {\small GASLIMIT} & 0 & 1 & Get the block's gas limit. \\
+0x45 & {\small GASLIMIT} & 0 & 1 & Get the current block's gas limit. \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv {I_{H}}_{\mathrm{l}}$ \\
 \bottomrule
 \end{tabu}


### PR DESCRIPTION
A transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the transaction cannot get the hash of the current block because the etc.

Also, FYI this white column persists even if you resize the page ^^