### PR TITLE
Add EIP 1344's ChainID opcode

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1903,7 +1903,7 @@ with $C_\text{\tiny CALL}$, $C_\text{\tiny SELFDESTRUCT}$ and $C_\text{\tiny SST
 
 $W_{zero}$ = \{{\small STOP}, {\small RETURN}, {\small REVERT}\}
 
-$W_{base}$ = \{{\small ADDRESS}, {\small ORIGIN}, {\small CALLER}, {\small CALLVALUE}, {\small CALLDATASIZE}, {\small CODESIZE}, {\small GASPRICE}, {\small COINBASE},\newline \noindent\hspace*{1cm} {\small TIMESTAMP}, {\small NUMBER}, {\small DIFFICULTY}, {\small GASLIMIT}, {\small RETURNDATASIZE}, {\small POP}, {\small PC}, {\small MSIZE}, {\small GAS}\}
+$W_{base}$ = \{{\small ADDRESS}, {\small ORIGIN}, {\small CALLER}, {\small CALLVALUE}, {\small CALLDATASIZE}, {\small CODESIZE}, {\small GASPRICE}, {\small COINBASE},\newline \noindent\hspace*{1cm} {\small TIMESTAMP}, {\small NUMBER}, {\small DIFFICULTY}, {\small GASLIMIT}, {\small RETURNDATASIZE}, {\small POP}, {\small PC}, {\small MSIZE}, {\small GAS}, {\small CHAINID} \}
 
 $W_{verylow}$ = \{{\small ADD}, {\small SUB}, {\small NOT}, {\small LT}, {\small GT}, {\small SLT}, {\small SGT}, {\small EQ}, {\small ISZERO}, {\small AND}, {\small OR}, {\small XOR}, {\small BYTE}, {\small SHL}, {\small SHR}, {\small SAR}, \newline \noindent\hspace*{1cm} {\small CALLDATALOAD}, {\small MLOAD}, {\small MSTORE}, {\small MSTORE8}, {\small PUSH*}, {\small DUP*}, {\small SWAP*}\}
 
@@ -2171,6 +2171,9 @@ Here given are the various exceptions to the state transition rules given in sec
 \midrule
 0x45 & {\small GASLIMIT} & 0 & 1 & Get the block's gas limit. \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv {I_{H}}_{\mathrm{l}}$ \\
+\midrule
+0x46 & {\small CHAINID} & 0 & 1 & Get the chain's id. \\
+&&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv \mathtt{chain\_id}$ \\
 \bottomrule
 \end{tabu}
 


### PR DESCRIPTION
Following EIP 1344

https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1344.md

this adds the `CHAINID` opcode to H2 Instruction Set.

![update](https://user-images.githubusercontent.com/17067072/120072521-9c9a9000-c094-11eb-8a36-4e3fc4cdc5fa.png)


Fixes https://github.com/ethereum/yellowpaper/issues/784