### PR TITLE
Block reward corrections

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1180,12 +1180,12 @@ R & \equiv & \left(1 + \frac{1}{8} (U_{\mathrm{i}} - {B_{H}}_{\mathrm{i}})\right
 
 If there are collisions of the beneficiary addresses between ommers and the block (i.e. two ommers with the same beneficiary address or an ommer with the same beneficiary address as the present block), additions are applied cumulatively.
 
-\hypertarget{block_reward_R__block}{}\linkdest{R__block}We define the block reward in Ether:
+\hypertarget{block_reward_R__block}{}\linkdest{R__block}We define the block reward in Wei:
 \begin{equation}
-\text{Let} \quad R_{\mathrm{block}} = 10^{18} \times \begin{cases}
+R_{\mathrm{block}} = 10^{18} \times \begin{cases}
 5 &\text{if}\ H_{\mathrm{i}} < 4370000 \\
-3 &\text{if}\ H_{\mathrm{i}} < 7280000 \\
-2 &\text{otherwise}
+3 &\text{if}\ 4370000 \leqslant H_{\mathrm{i}} < 7280000 \\
+2 &\text{if}\ H_{\mathrm{i}} \geqslant 7280000 \\
 \end{cases} \\
 \end{equation}
 


### PR DESCRIPTION
Block reward is actually specified in Wei, not in Ether.
Also, make the cases more explicit and mutually exclusive.

Before
<img width="369" alt="Screenshot 2021-06-11 at 15 02 43" src="https://user-images.githubusercontent.com/34320705/121690941-bdb4a500-cac6-11eb-8a18-4f4c1f3bcc9f.png">

After
<img width="361" alt="Screenshot 2021-06-11 at 15 04 07" src="https://user-images.githubusercontent.com/34320705/121690965-c4dbb300-cac6-11eb-8fa2-72de800b569a.png">
