### PR TITLE
Amendment: transaction sender might not exists

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -655,7 +655,6 @@ The validity is determined as:
 \begin{equation}
 \begin{array}[t]{rcl}
 S(T) & \neq & \varnothing \quad \wedge \\
-\boldsymbol{\sigma}[S(T)] & \neq & \varnothing \quad \wedge \\
 \boldsymbol{\sigma}[S(T)]_{\mathrm{c}} & = & \texttt{KEC}\big( () \big) \quad \wedge \\
 \linkdest{transaction_nonce}{}T_{\mathrm{n}} & = & \boldsymbol{\sigma}[S(T)]_{\mathrm{n}} \quad \wedge \\
 g_0 & \leqslant & T_{\mathrm{g}} \quad \wedge \\
@@ -663,8 +662,8 @@ v_0 & \leqslant & \boldsymbol{\sigma}[S(T)]_{\mathrm{b}} \quad \wedge \\
 T_{\mathrm{g}} & \leqslant & {B_{\mathrm{H}}}_{\mathrm{l}} - \hyperlink{ell}{\ell}(B_{\mathbf{R}})_{\mathrm{u}}
 \end{array}
 \end{equation}
-
 Note the final condition; the sum of the transaction's gas limit, $T_{\mathrm{g}}$, and the gas utilised in this block prior, given by $\hyperlink{ell}{\ell}(B_{\mathbf{R}})_{\mathrm{u}}$, must be no greater than the block's \textbf{gasLimit}, ${B_{\mathrm{H}}}_{\mathrm{l}}$.
+Also, with a slight abuse of notation, we assume that $\boldsymbol{\sigma}[S(T)]_{\mathrm{c}} = \texttt{KEC}\big( () \big)$, $\boldsymbol{\sigma}[S(T)]_{\mathrm{n}} = 0$, and $\boldsymbol{\sigma}[S(T)]_{\mathrm{b}} = 0$ if $\boldsymbol{\sigma}[S(T)] = \varnothing$.
 
 The execution of a valid transaction begins with an irrevocable change made to the state: the \hyperlink{account_nonce}{nonce of the account of the sender}, $S(T)$, is incremented by one and the balance is reduced by part of the up-front cost, $T_{\mathrm{g}}T_{\mathrm{p}}$. The gas available for the proceeding computation, $g$, is defined as $T_{\mathrm{g}} - g_0$. The computation, whether contract creation or a message call, results in an eventual state (which may legally be equivalent to the current state), the change to which is deterministic and never invalid: there can be no invalid transactions from this point.
 


### PR DESCRIPTION
Currently the Yellow Paper states that transactions from a non-existing sender are invalid. However, historically there've been such transactions with 0 gas price, for example https://etherscan.io/tx/0x0874e15fd07f92bf1143f9abd289c7c0737330782457b9c15d51666021b1194a.

Also, geth does allow such transactions (see [preCheck](https://github.com/ethereum/go-ethereum/blob/v1.10.11/core/state_transition.go#L217) and [statedb.go](https://github.com/ethereum/go-ethereum/blob/v1.10.11/core/state/statedb.go#L260)).

This change amends the Yellow Paper to account for such transactions.
Before:
![Screenshot 2021-11-01 at 13 23 21 png](https://user-images.githubusercontent.com/34320705/139671993-478ca3fb-dbb7-49ea-9509-b9abc1e9d374.png)
After:
![Screenshot 2021-11-01 at 13 22 13 png](https://user-images.githubusercontent.com/34320705/139672006-c181342f-8dea-455d-9d31-6f3d50afc2d9.png)

 