### PR TITLE
Fix rendering of Bloom filter formula

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -420,16 +420,15 @@ We define the Bloom filter function, $M$, to reduce a log entry into a single 25
 \begin{equation}
 M(O) \equiv \hyperlink{bigvee}{\bigvee}_{x \in \{O_{\mathrm{a}}\} \cup O_{\mathbf{t}}} \big( M_{3:2048}(x) \big)
 \end{equation}
-
 where $M_{3:2048}$ is a specialised Bloom filter that sets three bits out of 2048, given an arbitrary byte sequence. It does this through taking the low-order 11 bits of each of the first three pairs of bytes in a Keccak-256 hash of the byte sequence.\footnote{11 bits $= 2^{2048}$, and the low-order 11 bits is the modulo 2048 of the operand, which is in this case is "each of the first three pairs of bytes in a Keccak-256 hash of the byte sequence."} Formally:
 \begin{eqnarray}
 M_{3:2048}(\mathbf{x}: \mathbf{x} \in \mathbb{B}) & \equiv & \mathbf{y}: \mathbf{y} \in \mathbb{B}_{256} \quad \text{where:}\\
 \mathbf{y} & = & (0, 0, ..., 0) \quad \text{except:}\\
-\forall i \in \{0, 2, 4\}&:&\mathcal{B}_{m(\mathbf{x}, i)}(\mathbf{y}) = 1\\
-m(\mathbf{x}, i) &\equiv& 2047 - (\mathtt{KEC}(\mathbf{x})[i, i + 1] \bmod 2048)
+\forall i \in \{0, 2, 4\}&:&\mathcal{B}_{2047 - m(\mathbf{x}, i)}(\mathbf{y}) = 1\\
+m(\mathbf{x}, i) &\equiv& \mathtt{KEC}(\mathbf{x})[i, i + 1] \bmod 2048
 \end{eqnarray}
-
-where $\mathcal{B}$ is the bit reference function such that $\mathcal{B}_{\mathrm{j}}(\mathbf{x})$ equals the bit of index $j$ (indexed from 0) in the byte array $\mathbf{x}$. Notably, it treats $\mathbf{x}$ as big-endian (more significant bits will have smaller indices).
+where $\mathcal{B}$ is the bit reference function such that $\mathcal{B}_{\mathrm{j}}(\mathbf{x})$ equals the bit of index $j$ (indexed from 0) in the byte array $\mathbf{x}$.
+Notably, it treats $\mathbf{x}$ as big-endian (more significant bits will have smaller indices).
 
 \subsubsection{Holistic Validity}
 


### PR DESCRIPTION
Small rendering fix after https://github.com/ethereum/yellowpaper/pull/820.

Before:
<img width="381" alt="Screenshot 2021-11-02 at 12 49 56" src="https://user-images.githubusercontent.com/34320705/139841280-3d597e92-b9cc-4fac-a63f-7a348e3cf90c.png">
After:
<img width="367" alt="Screenshot 2021-11-02 at 12 49 26" src="https://user-images.githubusercontent.com/34320705/139841313-b4422af3-f72d-45a3-b3fc-73fd4e0930b1.png">


