### PR TITLE
Arrow Glacier network upgrade

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -4,7 +4,7 @@ Each protocol version is specified in `Paper.tex` found in a branch of this repo
 
 | Branch            | Version                                                           | Applicable Block Numbers        |
 |-------------------|-------------------------------------------------------------------------------------------------------------------|-----------------------------------|
-| TBD               | [London](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)        | Since 12,965,000 and onwards      |
+| TBD               | [Arrow Glacier](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md) <br> [London](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)        | Since 13,773,000 and onwards <br> Since 12,965,000 until 13,772,999 |
 | master            | [Berlin](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md)        | Since 12,244,000 until 12,964,999 |
 | istanbul          | [Muir Glacier](https://eips.ethereum.org/EIPS/eip-2387) <br> [Istanbul](https://eips.ethereum.org/EIPS/eip-1679)  | Since 9,200,000 until 12,243,999 <br> Since 9,069,000 until 9,199,999 |
 | petersburg        | [Constantinople](https://eips.ethereum.org/EIPS/eip-1013) + [Petersburg](https://eips.ethereum.org/EIPS/eip-1716) | Since 7,280,000 until 9,068,999   |

--- a/Biblio.bib
+++ b/Biblio.bib
@@ -170,12 +170,28 @@ and Gilles Van Assche",
 	month = "September",
 }
 
+@Misc{EIP-3554,
+	url = "https://eips.ethereum.org/EIPS/eip-3554",
+	title = "{EIP}-3554: Difficulty Bomb Delay to {December} 2021",
+	author = "Hancock, James",
+	year = "2021",
+	month = "May",
+}
+
 @Misc{EIP-3607,
 	url = "https://eips.ethereum.org/EIPS/eip-3607",
 	title = "{EIP}-3607: Reject transactions from senders with deployed code",
 	author = "Feist, Dankrad and Khovratovich, Dmitry and van der Wijden, Marius",
 	year = "2021",
 	month = "June",
+}
+
+@Misc{EIP-4345,
+	url = "https://eips.ethereum.org/EIPS/eip-4345",
+	title = "{EIP}-4345: Difficulty Bomb Delay to {June} 2022",
+	author = "Beiko, Tim and Hancock, James and Rush, Thomas Jay",
+	year = "2021",
+	month = "October",
 }
 
 @Misc{cryptoeprint:2013:881,

--- a/Paper.tex
+++ b/Paper.tex
@@ -190,6 +190,7 @@ $F_{\mathrm{Istanbul}}$          &  9069000 \\
 $F_{\mathrm{Muir Glacier}}$      &  9200000 \\
 $F_{\mathrm{Berlin}}$            & 12244000 \\
 $F_{\mathrm{London}}$            & 12965000 \\
+$F_{\mathrm{Arrow Glacier}}$     & 13773000 \\
 \bottomrule
 \end{tabular}
 \end{center}
@@ -535,7 +536,8 @@ H'_{\mathrm{i}} &\equiv \max(H_{\mathrm{i}} - \kappa, 0) \\
   3000000  & \text{if} \quad F_{\mathrm{Byzantium}} \leqslant H_{\mathrm{i}} < F_{\mathrm{Constantinople}} \\
   5000000  & \text{if} \quad F_{\mathrm{Constantinople}} \leqslant H_{\mathrm{i}} < F_{\mathrm{Muir Glacier}} \\
   9000000  & \text{if} \quad F_{\mathrm{Muir Glacier}} \leqslant H_{\mathrm{i}} < F_{\mathrm{London}} \\
-  9700000  & \text{if} \quad H_{\mathrm{i}} \geqslant F_{\mathrm{London}} \\
+  9700000  & \text{if} \quad F_{\mathrm{London}} \leqslant H_{\mathrm{i}} < F_{\mathrm{Arrow Glacier}} \\
+ 10700000  & \text{if} \quad H_{\mathrm{i}} \geqslant F_{\mathrm{Arrow Glacier}} \\
 \end{cases}
 \end{align}
 
@@ -545,7 +547,7 @@ This effect, known as the "difficulty bomb", or "ice age", was explained in EIP-
 $\homesteadmod$ was also modified in EIP-100 with the use of $x$, the adjustment factor above, and the denominator 9, in order to target the mean block time including uncle blocks by \cite{EIP-100}.
 In the \textit{Byzantium} release, with EIP-649, the ice age was delayed by creating a fake block number, $H'_{\mathrm{i}}$, which is obtained by subtracting three million from the actual block number,
 which in other words reduced $\expdiffsymb$ and the time difference between blocks, in order to allow more time to develop proof-of-stake and preventing the network from "freezing" up.
-Subsequently, with EIP-1234 by \cite{EIP-1234} and EIP-2384 by \cite{EIP-2384} the subtrahend $\kappa$ was increased to five and nine million respectively.
+Subsequently, EIP-1234 by \cite{EIP-1234}, EIP-2384 by \cite{EIP-2384}, EIP-3554 by \cite{EIP-3554}, and EIP-4345 by \cite{EIP-4345} increased the subtrahend $\kappa$.
 
 \hypertarget{block_gas_limit_H__l}{}The canonical gas limit $H_{\mathrm{l}}$ of a block of header $H$ must fulfil the relation:
 \begin{eqnarray}


### PR DESCRIPTION
Mention [Arrow Glacier](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md) network upgrade. It's specified in a compatible manner, so can be done before the rest of Berlin and London.