### PR TITLE
corrected the definition of N_n on page 5 eq.(18)

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -347,7 +347,7 @@ T_{\mathrm{s}} \in \mathbb{N}_{256} & \wedge & T_{\mathbf{d}} \in \mathbb{B} & \
 \end{equation}
 where
 \begin{equation}
-\mathbb{N}_{\mathrm{n}} = \{ P: P \in \mathbb{N} \wedge P < 2^n \}
+\mathbb{N}_{\mathrm{n}} = \{ P: P \in \mathbb{N} \wedge P < (2^3)^n \}
 \end{equation}
 
 The address hash $T_{\mathbf{t}}$ is slightly different: it is either a 20-byte address hash or, in the case of being a contract-creation transaction (and thus formally equal to $\varnothing$), it is the RLP empty byte sequence and thus the member of $\mathbb{B}_0$:


### PR DESCRIPTION
- Current version defines elements belonging to N_n has to be less than 2^n (i.e., in bits) => but it should be in bytes < (2^3)^n
- For example N_256 should represents elements that can be written in 256 bytes (not 256 bits)