### PR TITLE
Update Rsclear from 15000 to 4800

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1913,7 +1913,7 @@ $G_{\mathrm{coldsload}}$ & 2100 & Cost of a cold storage access. \\
 $G_{\mathrm{sset}}$ & 20000 & Paid for an {\small SSTORE} operation when the storage value is set to non-zero from zero. \\
 $G_{\mathrm{sreset}}$ & 2900 & Paid for an {\small SSTORE} operation when the storage value's zeroness remains unchanged or\\
 &&is set to zero. \\
-$R_{\mathrm{sclear}}$ & 15000 & Refund given (added into refund counter) when the storage value is set to zero from\\
+$R_{\mathrm{sclear}}$ & 4800 & Refund given (added into refund counter) when the storage value is set to zero from\\
 &&non-zero.\\
 \linkdest{R__selfdestruct}{}$R_{\mathrm{selfdestruct}}$ & 24000 & Refund given (added into refund counter) for self-destructing an account. \\
 \linkdest{G__selfdestruct}{}$G_{\mathrm{selfdestruct}}$ & 5000 & Amount of gas to pay for a {\small SELFDESTRUCT} operation. \\


### PR DESCRIPTION
Adjusting the value of Rsclear as suggested by [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529)

Old:
![image](https://user-images.githubusercontent.com/34151148/147483841-91b0687b-1238-4289-8741-4d611c28efb5.png)

New:
<img width="1138" alt="Screen Shot 2021-12-27 at 3 55 45 pm" src="https://user-images.githubusercontent.com/34151148/147483859-d18ce9a8-9d9c-443e-baee-33f1b9b100fd.png">

