### PR TITLE
EIP-2930: Optional access lists (Berlin Update Part 2)

### DIFF
--- a/Biblio.bib
+++ b/Biblio.bib
@@ -162,12 +162,28 @@ and Gilles Van Assche",
 	month = "November",
 }
 
+@Misc{EIP-2718,
+	url = "https://eips.ethereum.org/EIPS/eip-2718",
+	title = "{EIP}-2718: Typed Transaction Envelope",
+	author = "Zoltu, Micah",
+	year = "2020",
+	month = "June",
+}
+
 @Misc{EIP-2929,
 	url = "https://eips.ethereum.org/EIPS/eip-2929",
 	title = "{EIP}-2929: Gas cost increases for state access opcodes",
 	author = "Buterin, Vitalik and Swende, Martin",
 	year = "2020",
 	month = "September",
+}
+
+@Misc{EIP-2930,
+	url = "https://eips.ethereum.org/EIPS/eip-2930",
+	title = "{EIP}-2930: Optional access lists",
+	author = "Buterin, Vitalik and Swende, Martin",
+	year = "2020",
+	month = "August",
 }
 
 @Misc{EIP-3554,

--- a/Paper.tex
+++ b/Paper.tex
@@ -325,12 +325,13 @@ All transaction types specify a number of common fields:
 
 EIP-2930 (type 1) transactions also have:
 \begin{description}
-\item[accessList]\linkdest{tx_access_list}{} TODO; formally $T_{\mathbf{a}}$.
+\item[accessList]\linkdest{tx_access_list}{} List of access entries to warm up; formally $T_{\mathbf{A}}$.
+Each access list entry $A$ is a tuple of an account address and a list of storage keys: $A \equiv (A_{\mathrm{a}}, A_{\mathbf{s}})$. 
 \item[chainId]\linkdest{tx_chain_id}{} Chain ID; formally $T_{\mathrm{c}}$. Must be equal to the network chain ID \hyperlink{chain_id}{$\beta$}.
 \item[yParity]\linkdest{tx_y_parity}{} Signature Y parity; formally $T_{\mathrm{y}}$.
 \end{description}
 
-Legacy transactions do not have an \textbf{accessList}, while \textbf{chainId} and \textbf{yParity} for legacy transactions are combined into a single value:
+Legacy transactions do not have an \textbf{accessList} ($T_{\mathbf{A}}=()$), while \textbf{chainId} and \textbf{yParity} for legacy transactions are combined into a single value:
 \begin{description}
 \item[w]\linkdest{T__w}{} A scalar value encoding Y parity and possibly chain ID; formally $T_{\mathrm{w}}$.
 $T_{\mathrm{w}} = 27 + T_{\mathrm{y}}$ or $T_{\mathrm{w}} = 2\beta + 35 + T_{\mathrm{y}}$ (see EIP-155 by \cite{EIP-155}).
@@ -355,7 +356,7 @@ Appendix \ref{app:signing} specifies the function, $S$, which maps transactions 
 \begin{equation}
 \linkdest{L_transaction} L_{\mathrm{T}}(T) \equiv \begin{cases}
 (T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, T_{\mathrm{w}}, T_{\mathrm{r}}, T_{\mathrm{s}}) & \text{if} \; T_{\mathrm{x}} = 0 \\
-(T_{\mathrm{c}}, T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, T_{\mathbf{a}}, T_{\mathrm{y}}, T_{\mathrm{r}}, T_{\mathrm{s}}) & \text{if} \; T_{\mathrm{x}} = 1 \\
+(T_{\mathrm{c}}, T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, T_{\mathbf{A}}, T_{\mathrm{y}}, T_{\mathrm{r}}, T_{\mathrm{s}}) & \text{if} \; T_{\mathrm{x}} = 1 \\
 \end{cases}
 \end{equation}
 where
@@ -366,7 +367,7 @@ T_{\mathbf{d}} & \text{otherwise}
 \end{cases}
 \end{equation}
 
-Here, we assume all components are interpreted by the RLP as integer values, with the exception of the access list $T_{\mathbf{a}}$ and the arbitrary length byte arrays $T_{\mathbf{i}}$ and $T_{\mathbf{d}}$.
+Here, we assume all components are interpreted by the RLP as integer values, with the exception of the access list $T_{\mathbf{A}}$ and the arbitrary length byte arrays $T_{\mathbf{i}}$ and $T_{\mathbf{d}}$.
 \begin{equation}
 \begin{array}[t]{lclclc}
 T_{\mathrm{x}} \in \{0, 1\} & \wedge & T_{\mathrm{c}} = \beta & \wedge & T_{\mathrm{n}} \in \mathbb{N}_{256} & \wedge \\
@@ -673,14 +674,15 @@ Thus $\boldsymbol{\sigma}'$ is the post-transactional state. We also define \hyp
 \subsection{Substate} \label{ch:substate}
 Throughout transaction execution, we accrue certain information that is acted upon immediately following the transaction. We call this the \textit{accrued transaction substate}, or \textit{accrued substate} for short, and represent it as $A$, which is a tuple:
 \begin{equation}
-A \equiv (A_{\mathbf{s}}, A_{\mathbf{l}}, A_{\mathbf{t}}, A_{\mathrm{r}}, A_{\mathbf{a}}, A_{\mathbf{k}})
+A \equiv (A_{\mathbf{s}}, A_{\mathbf{l}}, A_{\mathbf{t}}, A_{\mathrm{r}}, A_{\mathbf{a}}, A_{\mathbf{K}})
 \end{equation}
 
 \hypertarget{self_destruct_set_wordy_defn_A__s}{}The tuple contents include $A_{\mathbf{s}}$, the self-destruct set: a set of accounts that will be discarded following the transaction's completion.
 \hypertarget{tx_log_series_wordy_defn_A__l}{} $A_{\mathbf{l}}$ is the log series: this is a series of archived and indexable `checkpoints' in VM code execution that allow for contract-calls to be easily tracked by onlookers external to the Ethereum world (such as decentralised application front-ends).
 \hypertarget{tx_touched_accounts_wordy_defn_A__t}{} $A_{\mathbf{t}}$ is the set of touched accounts, of which the empty ones are deleted at the end of a transaction.
 \hypertarget{refund_balance_defn_words_A__r}{}$A_{\mathrm{r}}$ is the refund balance, increased through using the \hyperlink{SSTORE}{{\small SSTORE}} instruction in order to reset contract storage to zero from some non-zero value. Though not immediately refunded, it is allowed to partially offset the total execution costs.
-Finally, EIP-2929 by \cite{EIP-2929} introduced \hypertarget{accessed_addresses_defn_words_A__a}{}$A_{\mathbf{a}}$, the set of accessed account addresses, and \hypertarget{accessed_storage_keys_defn_words_A__k}{}$A_{\mathbf{k}}$, the set of accessed storage keys.
+Finally, EIP-2929 by \cite{EIP-2929} introduced \hypertarget{accessed_addresses_defn_words_A__a}{}$A_{\mathbf{a}}$, the set of accessed account addresses, and \hypertarget{accessed_storage_keys_defn_words_A__k}{}$A_{\mathbf{K}}$, the set of accessed storage keys
+(more accurately, each element of $A_{\mathbf{K}}$ is a tuple of a 20-byte account address and a 32-byte storage slot).
 
 We define the empty accrued substate $A^0$ to have no self-destructs, no logs, no touched accounts, zero refund balance, all precompiled contracts in the accessed addresses, and no accessed storage:
 \begin{equation}
@@ -693,9 +695,13 @@ where $\hyperlink{precompiled_set}{\pi}$ is the set of all precompiled addresses
 \begin{align}
 g_0 \equiv {} & \sum_{i \in T_{\mathbf{i}}, T_{\mathbf{d}}} \begin{cases} \hyperlink{G__txdatazero}{G_{\mathrm{txdatazero}}} & \text{if} \quad i = 0 \\ \hyperlink{G__txdatanonzero}{G_{\mathrm{txdatanonzero}}} & \text{otherwise} \end{cases} \\
 \nonumber {} & + \begin{cases} \hyperlink{G__txcreate}{G_{\mathrm{txcreate}}} & \text{if} \quad T_{\mathrm{t}} = \varnothing \\ 0 & \text{otherwise} \end{cases} \\
-\nonumber {} & + \hyperlink{G__transaction}{G_{\mathrm{transaction}}}
+\nonumber {} & + \hyperlink{G__transaction}{G_{\mathrm{transaction}}} \\
+\nonumber {} & + \sum_{j = 0}^{\lVert T_{\mathbf{A}} \rVert - 1} \big( G_{\mathrm{accesslistaddress}} + \lVert T_{\mathbf{A}}[j]_{\mathbf{s}} \rVert G_{\mathrm{accessliststorage}} \big)
 \end{align}
-where $T_{\mathbf{i}},T_{\mathbf{d}}$ means the series of bytes of the transaction's associated data and initialisation EVM-code, depending on whether the transaction is for contract-creation or message-call. $G_{\mathrm{txcreate}}$ is added if the transaction is contract-creating, but not if a result of EVM-code. $G$ is fully defined in Appendix \ref{app:fees}.
+where $T_{\mathbf{i}},T_{\mathbf{d}}$ means the series of bytes of the transaction's associated data and initialisation EVM-code, depending on whether the transaction is for contract-creation or message-call.
+$G_{\mathrm{txcreate}}$ is added if the transaction is contract-creating, but not if a result of EVM-code.
+$\hyperlink{G__accesslistaddress}{G_{\mathrm{accesslistaddress}}}$ and $\hyperlink{G__accessliststorage}{G_{\mathrm{accessliststorage}}}$ are the costs of warming up account and storage access, respectively.
+$G$ is fully defined in Appendix \ref{app:fees}.
 
 The up-front cost $v_0$ is calculated as:
 \begin{equation}
@@ -733,9 +739,11 @@ Evaluating $\boldsymbol{\sigma}_{\mathrm{P}}$ from $\boldsymbol{\sigma}_0$ depen
 \end{cases}
 \end{equation}
 where
-\begin{equation}
-A^* \equiv A^0 \quad \text{except} \quad A^*_{\mathbf{a}} \equiv A^0_{\mathbf{a}} \cup \{S(T)\}
-\end{equation}
+\begin{align}
+A^* & \equiv A^0 \quad \text{except} \\
+A^*_{\mathbf{a}} & \equiv A^0_{\mathbf{a}} \cup \{S(T)\} \cup \{ T_{\mathbf{A}}[i]_{\mathrm{a}}, \; i < \lVert T_{\mathbf{A}} \rVert \} \\
+A^*_{\mathbf{K}} & \equiv A^0_{\mathbf{K}} \bigcup_{i = 0}^{\lVert T_{\mathbf{A}} \rVert - 1} \{ (T_{\mathbf{A}}[i]_{\mathrm{a}}, T_{\mathbf{A}}[i]_{\mathbf{s}}[j]), \; j < \lVert T_{\mathbf{A}}[i]_{\mathbf{s}} \rVert \}
+\end{align}
 and $g$ is the amount of gas remaining after deducting the basic amount required to pay for the existence of the transaction:
 \begin{equation}
 g \equiv T_{\mathrm{g}} - g_0
@@ -1914,7 +1922,7 @@ A(p_{\mathrm{r}}) = \mathcal{B}_{96..255}\big(\mathtt{KEC}\big( \mathtt{ECDSAPUB
 L_{\mathrm{X}}(T) & \equiv & \begin{cases}
 (T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}) & \text{if} \; T_{\mathrm{x}} = 0 \land T_{\mathrm{w}} \in \{27, 28\} \\
 (T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, \beta, (), ()) & \text{if} \; T_{\mathrm{x}} = 0 \land T_{\mathrm{w}} \in \{2\beta + 35, 2\beta + 36\} \\
-(T_{\mathrm{c}}, T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, T_{\mathbf{a}}) & \text{if} \; T_{\mathrm{x}} = 1
+(T_{\mathrm{c}}, T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, T_{\mathbf{A}}) & \text{if} \; T_{\mathrm{x}} = 1
 \end{cases} \\
 \nonumber \text{where} \\
 \nonumber \mathbf{p} & \equiv & \begin{cases}
@@ -1973,8 +1981,8 @@ $G_{\mathrm{low}}$ & 5 & Amount of gas to pay for operations of the set {\small 
 $G_{\mathrm{mid}}$ & 8 & Amount of gas to pay for operations of the set {\small $W_{\mathrm{mid}}$}. \\
 $G_{\mathrm{high}}$ & 10 & Amount of gas to pay for operations of the set {\small $W_{\mathrm{high}}$}. \\
 $G_{\mathrm{warmaccess}}$ & 100 & Cost of a warm account or storage access. \\
-$G_{\mathrm{accesslistaddress}}$ & 2400 & Cost of warming up an account with the access list. \\
-$G_{\mathrm{accessliststorage}}$ & 1900 & Cost of warming up a storage with the access list. \\
+\linkdest{G__accesslistaddress}{}$G_{\mathrm{accesslistaddress}}$ & 2400 & Cost of warming up an account with the access list. \\
+\linkdest{G__accessliststorage}{}$G_{\mathrm{accessliststorage}}$ & 1900 & Cost of warming up a storage with the access list. \\
 $G_{\mathrm{coldaccountaccess}}$ & 2600 & Cost of a cold account access. \\
 $G_{\mathrm{coldsload}}$ & 2100 & Cost of a cold storage access. \\
 $G_{\mathrm{sset}}$ & 20000 & Paid for an {\small SSTORE} operation when the storage value is set to non-zero from zero. \\
@@ -2388,16 +2396,16 @@ Here given are the various exceptions to the state transition rules given in sec
 \midrule
 0x54 & {\small SLOAD} & 1 & 1 & Load word from storage. \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{s}}[0] \equiv \boldsymbol{\sigma}[I_{\mathrm{a}}]_{\mathbf{s}}[\boldsymbol{\mu}_{\mathbf{s}}[0]]$ \\
-&&&& $A'_{\mathbf{k}} \equiv A_{\mathbf{k}} \cup \{(I_{\mathrm{a}}, \boldsymbol{\mu}_{\mathbf{s}}[0])\}$ \\
+&&&& $A'_{\mathbf{K}} \equiv A_{\mathbf{K}} \cup \{(I_{\mathrm{a}}, \boldsymbol{\mu}_{\mathbf{s}}[0])\}$ \\
 &&&& $C_{\text{\tiny SLOAD}}(\boldsymbol{\mu}, A, I) \equiv
 \begin{cases}
-G_{\mathrm{warmaccess}} & \text{if} \quad (I_{\mathrm{a}}, \boldsymbol{\mu}_{\mathbf{s}}[0]) \in A_{\mathbf{k}} \\
+G_{\mathrm{warmaccess}} & \text{if} \quad (I_{\mathrm{a}}, \boldsymbol{\mu}_{\mathbf{s}}[0]) \in A_{\mathbf{K}} \\
 G_{\mathrm{coldsload}}  & \text{otherwise}
 \end{cases}$ \\
 \midrule
 \linkdest{SSTORE}{}0x55 & {\small SSTORE} & 2 & 0 & Save word to storage. \\
 &&&& $\boldsymbol{\sigma}'[I_{\mathrm{a}}]_{\mathbf{s}}[ \boldsymbol{\mu}_{\mathbf{s}}[0] ] \equiv \boldsymbol{\mu}_{\mathbf{s}}[1] $ \\
-&&&& $A'_{\mathbf{k}} \equiv A_{\mathbf{k}} \cup \{(I_{\mathrm{a}}, \boldsymbol{\mu}_{\mathbf{s}}[0])\}$ \\
+&&&& $A'_{\mathbf{K}} \equiv A_{\mathbf{K}} \cup \{(I_{\mathrm{a}}, \boldsymbol{\mu}_{\mathbf{s}}[0])\}$ \\
 &&&&\linkdest{C__SSTORE}{}$C_{\text{\tiny SSTORE}}(\boldsymbol{\sigma}, \boldsymbol{\mu})$ and \linkdest{A r}{}$A'_{\mathrm{r}}$ are specified by EIP-2200 as follows. \\
 &&&& We remind the reader that the checkpoint (``original'') state $\hyperlink{sigma_0}{\boldsymbol{\sigma}_0}$ is the state \\
 &&&& if the current transaction were to revert. \\
@@ -2408,7 +2416,7 @@ G_{\mathrm{coldsload}}  & \text{otherwise}
 &&&& $\!\begin{aligned}
 C_{\text{\tiny SSTORE}}(\boldsymbol{\sigma}, \boldsymbol{\mu}, A, I) &\equiv
 \begin{cases}
-0                      & \text{if} \quad (I_{\mathrm{a}}, \boldsymbol{\mu}_{\mathbf{s}}[0]) \in A_{\mathbf{k}} \\
+0                      & \text{if} \quad (I_{\mathrm{a}}, \boldsymbol{\mu}_{\mathbf{s}}[0]) \in A_{\mathbf{K}} \\
 G_{\mathrm{coldsload}} & \text{otherwise} \\
 \end{cases} \\
 &+

--- a/Paper.tex
+++ b/Paper.tex
@@ -742,7 +742,7 @@ where
 \begin{align}
 A^* & \equiv A^0 \quad \text{except} \\
 A^*_{\mathbf{a}} & \equiv A^0_{\mathbf{a}} \cup \{S(T)\} \cup \{ T_{\mathbf{A}}[i]_{\mathrm{a}}, \; i < \lVert T_{\mathbf{A}} \rVert \} \\
-A^*_{\mathbf{K}} & \equiv A^0_{\mathbf{K}} \bigcup_{i = 0}^{\lVert T_{\mathbf{A}} \rVert - 1} \{ (T_{\mathbf{A}}[i]_{\mathrm{a}}, T_{\mathbf{A}}[i]_{\mathbf{s}}[j]), \; j < \lVert T_{\mathbf{A}}[i]_{\mathbf{s}} \rVert \}
+A^*_{\mathbf{K}} & \equiv \bigcup_{i = 0}^{\lVert T_{\mathbf{A}} \rVert - 1} \{ (T_{\mathbf{A}}[i]_{\mathrm{a}}, T_{\mathbf{A}}[i]_{\mathbf{s}}[j]), \; j < \lVert T_{\mathbf{A}}[i]_{\mathbf{s}} \rVert \}
 \end{align}
 and $g$ is the amount of gas remaining after deducting the basic amount required to pay for the existence of the transaction:
 \begin{equation}
@@ -758,7 +758,7 @@ After the message call or contract creation is processed, the refund counter has
 
 Then the state is finalised by determining the amount to be refunded, $g^*$ from the remaining gas, $g'$, plus some allowance from the refund counter, to the sender at the original rate.
 \begin{equation}
-g^* \equiv g' + \min \left\{ \Big\lfloor \dfrac{T_{\mathrm{g}} - g'}{2} \Big\rfloor, \hyperlink{refund_balance_defn_words_A__r}{A'_{\mathrm{r}}} \right\}
+g^* \equiv g' + \min \left\{ \Big\lfloor \dfrac{T_{\mathrm{g}} - g'}{2} \Big\rfloor, A'_{\mathrm{r}} \right\}
 \end{equation}
 
 The total refundable amount is the legitimately remaining gas $g'$, added to \hyperlink{refund_balance_defn_words_A__r}{$A_{\mathrm{r}}$}, with the latter component being capped up to a maximum of half (rounded down) of the total amount used $T_{\mathrm{g}} - g'$. Therefore, $g^*$ is the total gas that remains after the transaction has been executed.

--- a/Paper.tex
+++ b/Paper.tex
@@ -337,7 +337,7 @@ Legacy transactions do not have an \textbf{accessList} ($T_{\mathbf{A}}=()$), wh
 $T_{\mathrm{w}} = 27 + T_{\mathrm{y}}$ or $T_{\mathrm{w}} = 2\beta + 35 + T_{\mathrm{y}}$ (see EIP-155 by \cite{EIP-155}).
 \end{description}
 
-Additionally, a contract creation transaction contains:
+Additionally, a contract creation transaction (regardless whether legacy or EIP-2930) contains:
 
 \begin{description}
 \item[init] An unlimited size byte array specifying the EVM-code for the account initialisation procedure, formally $T_{\mathbf{i}}$.

--- a/Paper.tex
+++ b/Paper.tex
@@ -303,15 +303,37 @@ An account is \textit{dead} when its account state is non-existent or empty:
 
 \subsection{The Transaction} \label{subsec:transaction}
 
-A transaction (formally, $T$) is a single cryptographically-signed instruction constructed by an actor externally to the scope of Ethereum. The sender of a transaction can not be a contract. While it is assumed that the ultimate external actor will be human in nature, software tools will be used in its construction and dissemination\footnote{Notably, such `tools' could ultimately become so causally removed from their human-based initiation---or humans may become so causally-neutral---that there could be a point at which they rightly be considered autonomous agents. \eg contracts may offer bounties to humans for being sent transactions to initiate their execution.}. There are two types of transactions: those which result in message calls and those which result in the creation of new accounts with associated code (known informally as `contract creation'). Both types specify a number of common fields:
+A transaction (formally, $T$) is a single cryptographically-signed instruction constructed by an actor externally to the scope of Ethereum.
+The sender of a transaction cannot be a contract.
+While it is assumed that the ultimate external actor will be human in nature, software tools will be used in its construction and dissemination\footnote{Notably,
+such `tools' could ultimately become so causally removed from their human-based initiation---or humans may become so causally-neutral---that there could be a point at which they rightly be considered autonomous agents.
+\eg contracts may offer bounties to humans for being sent transactions to initiate their execution.}.
+EIP-2718 by \cite{EIP-2718} introduced the notion of different transaction types.
+As of the Berlin version of the protocol, there are two transaction types: 0 (legacy) and 1 (EIP-2930 by \cite{EIP-2930}).
+Further, there are two subtypes of transactions: those which result in message calls and those which result in the creation of new accounts with associated code (known informally as `contract creation').
+All transaction types specify a number of common fields:
 
 \begin{description}
+\item[type]\linkdest{tx_type}{} EIP-2718 transaction type; formally $T_{\mathrm{x}}$.
 \item[nonce]\linkdest{tx_nonce}{} A scalar value equal to the number of transactions sent by the sender; formally $T_{\mathrm{n}}$.
 \item[gasPrice]\linkdest{tx_gas_price_T__p}{} A scalar value equal to the number of Wei to be paid per unit of \textit{gas} for all computation costs incurred as a result of the execution of this transaction; formally $T_{\mathrm{p}}$.
 \item[gasLimit]\linkdest{tx_gas_limit_T__g}{} A scalar value equal to the maximum amount of gas that should be used in executing this transaction. This is paid up-front, before any computation is done and may not be increased later; formally $T_{\mathrm{g}}$.
 \item[to]\linkdest{tx_to_address_T__t}{} The 160-bit address of the message call's recipient or, for a contract creation transaction, $\varnothing$, used here to denote the only member of $\mathbb{B}_0$ ; formally $T_{\mathrm{t}}$.
 \item[value]\linkdest{tx_value_T__v}{} A scalar value equal to the number of Wei to be transferred to the message call's recipient or, in the case of contract creation, as an endowment to the newly created account; formally $T_{\mathrm{v}}$.
-\item[v, r, s] Values corresponding to the signature of the transaction and used to determine the sender of the transaction; formally \linkdest{T__w_T__r_T__s}{$T_{\mathrm{w}}$, $T_{\mathrm{r}}$ and $T_{\mathrm{s}}$}. This is expanded in Appendix \ref{app:signing}.
+\item[r, s] Values corresponding to the signature of the transaction and used to determine the sender of the transaction; formally {$T_{\mathrm{r}}$ and $T_{\mathrm{s}}$}. This is expanded in Appendix \ref{app:signing}.
+\end{description}
+
+EIP-2930 (type 1) transactions also have:
+\begin{description}
+\item[accessList]\linkdest{tx_access_list}{} TODO; formally $T_{\mathbf{a}}$.
+\item[chainId]\linkdest{tx_chain_id}{} Chain ID; formally $T_{\mathrm{c}}$. Must be equal to the network chain ID \hyperlink{chain_id}{$\beta$}.
+\item[yParity]\linkdest{tx_y_parity}{} Signature Y parity; formally $T_{\mathrm{y}}$.
+\end{description}
+
+Legacy transactions do not have an \textbf{accessList}, while \textbf{chainId} and \textbf{yParity} for legacy transactions are combined into a single value:
+\begin{description}
+\item[w] A scalar value encoding Y parity and possibly chain ID; \linkdest{T__w_T__r_T__s}formally $T_{\mathrm{w}}$.
+$T_{\mathrm{w}} = 27 + T_{\mathrm{y}}$ or $T_{\mathrm{w}} = 2\beta + 35 + T_{\mathrm{y}}$ (see EIP-155 by \cite{EIP-155}).
 \end{description}
 
 Additionally, a contract creation transaction contains:
@@ -331,18 +353,26 @@ In contrast, a message call transaction contains:
 Appendix \ref{app:signing} specifies the function, $S$, which maps transactions to the sender, and happens through the ECDSA of the SECP-256k1 curve, using the hash of the transaction (excepting the latter three signature fields) as the datum to sign. For the present we simply assert that the sender of a given transaction $T$ can be represented with $S(T)$.
 
 \begin{equation}
-L_{\mathrm{T}}(T) \equiv \begin{cases}
-(T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, T_{\mathbf{i}}, T_{\mathrm{w}}, T_{\mathrm{r}}, T_{\mathrm{s}}) & \text{if} \; T_{\mathrm{t}} = \varnothing\\
-(T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, T_{\mathbf{d}}, T_{\mathrm{w}}, T_{\mathrm{r}}, T_{\mathrm{s}}) & \text{otherwise}
+\linkdest{L_transaction} L_{\mathrm{T}}(T) \equiv \begin{cases}
+(T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, T_{\mathrm{w}}, T_{\mathrm{r}}, T_{\mathrm{s}}) & \text{if} \; T_{\mathrm{x}} = 0 \\
+(T_{\mathrm{c}}, T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, T_{\mathbf{a}}, T_{\mathrm{y}}, T_{\mathrm{r}}, T_{\mathrm{s}}) & \text{if} \; T_{\mathrm{x}} = 1 \\
+\end{cases}
+\end{equation}
+where
+\begin{equation}
+\mathbf{p} \equiv \begin{cases}
+T_{\mathbf{i}} & \text{if}\ T_{\mathrm{t}} = \varnothing \\
+T_{\mathbf{d}} & \text{otherwise}
 \end{cases}
 \end{equation}
 
-Here, we assume all components are interpreted by the RLP as integer values, with the exception of the arbitrary length byte arrays $T_{\mathbf{i}}$ and $T_{\mathbf{d}}$.
+Here, we assume all components are interpreted by the RLP as integer values, with the exception of the access list $T_{\mathbf{a}}$ and the arbitrary length byte arrays $T_{\mathbf{i}}$ and $T_{\mathbf{d}}$.
 \begin{equation}
 \begin{array}[t]{lclclc}
-T_{\mathrm{n}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{v}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{p}} \in \mathbb{N}_{256} & \wedge \\
-T_{\mathrm{g}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{w}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{r}} \in \mathbb{N}_{256} & \wedge \\
-T_{\mathrm{s}} \in \mathbb{N}_{256} & \wedge & T_{\mathbf{d}} \in \mathbb{B} & \wedge & T_{\mathbf{i}} \in \mathbb{B}
+T_{\mathrm{x}} \in \{0, 1\} & \wedge & T_{\mathrm{c}} = \beta & \wedge & T_{\mathrm{n}} \in \mathbb{N}_{256} & \wedge \\
+T_{\mathrm{p}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{g}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{v}} \in \mathbb{N}_{256} & \wedge \\
+T_{\mathrm{w}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{r}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{s}} \in \mathbb{N}_{256} & \wedge \\
+T_{\mathrm{y}} \in \mathbb{N}_{1} & \wedge & T_{\mathbf{d}} \in \mathbb{B} & \wedge & T_{\mathbf{i}} \in \mathbb{B}
 \end{array}
 \end{equation}
 where
@@ -438,7 +468,7 @@ Notably, it treats $\mathbf{x}$ as big-endian (more significant bits will have s
 \begin{array}[t]{lclc}
 \linkdest{new_state_H__r}{}H_{\mathrm{r}} &\equiv& \mathtt{TRIE}(L_S(\Pi(\boldsymbol{\sigma}, B))) & \wedge \\
 \linkdest{Ommer_block_hash_H__o}{}H_{\mathrm{o}} &\equiv& \mathtt{KEC}(\mathtt{RLP}(L_H^*(B_{\mathbf{U}}))) & \wedge \\
-\linkdest{tx_block_hash_H__t}{}H_{\mathrm{t}} &\equiv& \mathtt{TRIE}(\{\forall i < \lVert B_{\mathbf{T}} \rVert, i \in \mathbb{N}: &\\&& \quad\quad p (i, L_{\mathrm{T}}(B_{\mathbf{T}}[i]))\}) & \wedge \\
+\linkdest{tx_block_hash_H__t}{}H_{\mathrm{t}} &\equiv& \mathtt{TRIE}(\{\forall i < \lVert B_{\mathbf{T}} \rVert, i \in \mathbb{N}: &\\&& \quad\quad p'(i, B_{\mathbf{T}}[i])\}) & \wedge \\
 \linkdest{Receipts_Root_H__e}{}H_{\mathrm{e}} &\equiv& \mathtt{TRIE}(\{\forall i < \lVert B_{\mathbf{R}} \rVert, i \in \mathbb{N}: &\\&& \quad\quad p(i, B_{\mathbf{R}}[i])\}) & \wedge \\
 \linkdest{logs_Bloom_filter_H__b}{}H_{\mathrm{b}} &\equiv& \bigvee_{\mathbf{r} \in B_{\mathbf{R}}} \big( \mathbf{r}_{\mathrm{b}} \big)
 \end{array}
@@ -447,6 +477,15 @@ where $p(k, v)$ is simply the pairwise RLP transformation, in this case, the fir
 \begin{equation}
 p(k, v) \equiv \big( \mathtt{RLP}(k), \mathtt{RLP}(v) \big)
 \end{equation}
+and $p'(k, T)$ is similar, but has a special treatment for EIP-2718 transactions:
+\begin{equation}
+p'(k, T) \equiv \left( \mathtt{RLP}(k), \begin{cases}
+\mathtt{RLP}(L_{\mathrm{T}}(T)) & \text{if} \quad T_{\mathrm{x}} = 0 \\
+T_{\mathrm{x}} \cdot \mathtt{RLP}(L_{\mathrm{T}}(T)) & \text{otherwise}
+\end{cases}
+\right)
+\end{equation}
+($\cdot$ is the concatenation of byte arrays).
 
 Furthermore:
 \begin{equation}
@@ -463,12 +502,18 @@ The values stemming from the computation of transactions, specifically the \hype
 We assert the types and order of the structure for when the RLP transformation is required:
 \begin{eqnarray}
 \quad L_{\mathrm{H}}(H) & \equiv & (\begin{array}[t]{l}H_{\mathrm{p}}, H_{\mathrm{o}}, H_{\mathrm{c}}, H_{\mathrm{r}}, H_{\mathrm{t}}, H_{\mathrm{e}}, H_{\mathrm{b}}, H_{\mathrm{d}},\\ H_{\mathrm{i}}, H_{\mathrm{l}}, H_{\mathrm{g}}, H_{\mathrm{s}}, H_{\mathrm{x}}, H_{\mathrm{m}}, H_{\mathrm{n}} \; )\end{array} \\
-\quad L_{\mathrm{B}}(B) & \equiv & \big( L_{\mathrm{H}}(B_{\mathrm{H}}), L_{\mathrm{T}}^*(B_{\mathbf{T}}), L_{\mathrm{H}}^*(\hyperlink{ommer_block_headers_B__U}{B_{\mathbf{U}}}) \big)
+\quad L_{\mathrm{B}}(B) & \equiv & \big( L_{\mathrm{H}}(B_{\mathrm{H}}), \widetilde{L}_{\mathrm{T}}^*(B_{\mathbf{T}}), L_{\mathrm{H}}^*(\hyperlink{ommer_block_headers_B__U}{B_{\mathbf{U}}}) \big)
 \end{eqnarray}
-
-\hypertarget{general_element_wise_sequence_transformation_f_pow_asterisk}{}With $L_T^*$ and $L_H^*$ being element-wise sequence transformations, thus:
+where $\widetilde{L}_{\mathrm{T}}$ takes a special care of EIP-2718 transactions:
 \begin{equation}
-\hyperlink{general_element_wise_sequence_transformation_f_pow_asterisk}{f^*}\big( (x_0, x_1, ...) \big) \equiv \big( f(x_0), f(x_1), ... \big) \quad \text{for any function} \; f
+\widetilde{L}_{\mathrm{T}}(T) = \begin{cases}
+\hyperlink{L_transaction}{L_{\mathrm{T}}}(T) & \text{if} \quad T_{\mathrm{x}} = 0 \\
+T_{\mathrm{x}} \cdot \mathtt{RLP}(L_{\mathrm{T}}(T)) & \text{otherwise}
+\end{cases}
+\end{equation}
+\hypertarget{general_element_wise_sequence_transformation_f_pow_asterisk}{}with $\widetilde{L}_{\mathrm{T}}^*$ and $L_{\mathrm{H}}^*$ being element-wise sequence transformations, thus:
+\begin{equation}
+f^*\big( (x_0, x_1, ...) \big) \equiv \big( f(x_0), f(x_1), ... \big) \quad \text{for any function} \; f
 \end{equation}
 
 The component types are defined thus:
@@ -635,10 +680,9 @@ where $\hyperlink{precompiled_set}{\pi}$ is the set of all precompiled addresses
 \hypertarget{intrinsic_gas_g_0}{}We define intrinsic gas $g_0$, the amount of gas this transaction requires to be paid prior to execution, as follows:
 \begin{align}
 g_0 \equiv {} & \sum_{i \in T_{\mathbf{i}}, T_{\mathbf{d}}} \begin{cases} \hyperlink{G__txdatazero}{G_{\mathrm{txdatazero}}} & \text{if} \quad i = 0 \\ \hyperlink{G__txdatanonzero}{G_{\mathrm{txdatanonzero}}} & \text{otherwise} \end{cases} \\
-{} & + \begin{cases} \hyperlink{G__txcreate}{G_{\mathrm{txcreate}}} & \text{if} \quad T_{\mathrm{t}} = \varnothing \\ 0 & \text{otherwise} \end{cases} \\
-{} & + \hyperlink{G__transaction}{G_{\mathrm{transaction}}}
+\nonumber {} & + \begin{cases} \hyperlink{G__txcreate}{G_{\mathrm{txcreate}}} & \text{if} \quad T_{\mathrm{t}} = \varnothing \\ 0 & \text{otherwise} \end{cases} \\
+\nonumber {} & + \hyperlink{G__transaction}{G_{\mathrm{transaction}}}
 \end{align}
-
 where $T_{\mathbf{i}},T_{\mathbf{d}}$ means the series of bytes of the transaction's associated data and initialisation EVM-code, depending on whether the transaction is for contract-creation or message-call. $G_{\mathrm{txcreate}}$ is added if the transaction is contract-creating, but not if a result of EVM-code. $G$ is fully defined in Appendix \ref{app:fees}.
 
 The up-front cost $v_0$ is calculated as:
@@ -1828,15 +1872,19 @@ We assume the existence of functions $\mathtt{ECDSAPUBKEY}$, $\mathtt{ECDSASIGN}
 \mathtt{ECDSARECOVER}(e \in \mathbb{B}_{32}, v \in \mathbb{B}_{1}, r \in \mathbb{B}_{32}, s \in \mathbb{B}_{32}) & \equiv & p_{\mathrm{u}} \in \mathbb{B}_{64}
 \end{eqnarray}
 
-Where $p_{\mathrm{u}}$ is the public key, assumed to be a byte array of size 64 (formed from the concatenation of two positive integers each $< 2^{256}$), $p_{\mathrm{r}}$ is the private key, a byte array of size 32 (or a single positive integer in the aforementioned range) and $e$ is the hash of the transaction, \hyperlink{h_of_T}{$h(T)$}. It is assumed that \hypertarget{v}{}$v$ is the `recovery identifier'. The recovery identifier is a 1 byte value specifying the parity and finiteness of the coordinates of the curve point for which $r$ is the x-value; this value is in the range of $[27, 30]$, however we declare the upper two possibilities, representing infinite values, invalid. The value 27 represents an even $y$ value and 28 represents an odd $y$ value.
+Where $p_{\mathrm{u}}$ is the public key, assumed to be a byte array of size 64 (formed from the concatenation of two positive integers each $< 2^{256}$),
+$p_{\mathrm{r}}$ is the private key, a byte array of size 32 (or a single positive integer in the aforementioned range) and $e$ is the hash of the transaction, \hyperlink{h_of_T}{$h(T)$}.
+It is assumed that \hypertarget{v}{}$v$ is the `recovery identifier'.
+The recovery identifier is a 1 byte value specifying the parity and finiteness of the coordinates of the curve point for which $r$ is the x-value; this value is in the range of $[0, 3]$, however we declare the upper two possibilities, representing infinite values, invalid.
+The value 0 represents an even $y$ value and 1 represents an odd $y$ value.
 
 \newcommand{\slimit}{\ensuremath{\text{s-limit}}}
 
-\linkdest{invalidsig}We declare that an ECDSA signature is invalid unless all the following conditions are true\footnote{A signature of a transaction can be valid not only with a recovery identifier but with some other numbers.  See \hyperlink{T__w}{how the component $T_w$ of a transaction is interpreted.}}:
+\linkdest{invalidsig}We declare that an ECDSA signature is invalid unless all the following conditions are true:
 \begin{align}
 0 < \linkdest{r}{r} &< \mathtt{secp256k1n} \\
 0 < \linkdest{s}{s} &< \mathtt{secp256k1n} \div 2 + 1 \\
-\hyperlink{v}{v} &\in \{27,28\}
+\hyperlink{v}{v} &\in \{0,1\}
 \end{align}
 where:
 \begin{align}
@@ -1849,24 +1897,28 @@ For a given private key, $p_{\mathrm{r}}$, the Ethereum address $A(p_{\mathrm{r}
 A(p_{\mathrm{r}}) = \mathcal{B}_{96..255}\big(\mathtt{KEC}\big( \mathtt{ECDSAPUBKEY}(p_{\mathrm{r}}) \big) \big)
 \end{equation}
 
-\hypertarget{h_of_T}{}The message hash, $h(T)$, to be signed is the Keccak-256 hash of the transaction. Two different flavors of signing schemes are available. One operates without the latter three signature components, formally described as $T_{\mathrm{r}}$, $T_{\mathrm{s}}$ and $T_{\mathrm{w}}$. The other operates on nine elements:
+\hypertarget{h_of_T}{}The message hash, $h(T)$, to be signed is the Keccak-256 hash of the transaction. Three different flavours of signing schemes are available:
 \begin{eqnarray}
-L_{\mathrm{S}}(T) & \equiv & \begin{cases}
-(T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}) & \text{if} \; v \in \{27, 28\} \\
-(T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, \beta, (), ()) & \text{otherwise} \\
+L_{\mathrm{X}}(T) & \equiv & \begin{cases}
+(T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}) & \text{if} \; T_{\mathrm{x}} = 0 \land T_{\mathrm{w}} \in \{27, 28\} \\
+(T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, \beta, (), ()) & \text{if} \; T_{\mathrm{x}} = 0 \land T_{\mathrm{w}} \in \{2\beta + 35, 2\beta + 36\} \\
+(T_{\mathrm{c}}, T_{\mathrm{n}}, T_{\mathrm{p}}, T_{\mathrm{g}}, T_{\mathrm{t}}, T_{\mathrm{v}}, \mathbf{p}, T_{\mathbf{a}}) & \text{if} \; T_{\mathrm{x}} = 1
 \end{cases} \\
 \nonumber \text{where} \\
 \nonumber \mathbf{p} & \equiv & \begin{cases}
-T_{\mathbf{i}} & \text{if}\ T_{\mathrm{t}} = 0 \\
+T_{\mathbf{i}} & \text{if}\ T_{\mathrm{t}} = \varnothing \\
 T_{\mathbf{d}} & \text{otherwise}
 \end{cases} \\
-h(T) & \equiv & \mathtt{KEC}( L_{\mathrm{S}}(T) )
+h(T) & \equiv & \begin{cases}
+\mathtt{KEC}( \mathtt{RLP}(L_{\mathrm{X}}(T)) ) & \text{if} \; T_{\mathrm{x}} = 0 \\
+\mathtt{KEC}( T_{\mathrm{x}} \cdot \mathtt{RLP}(L_{\mathrm{X}}(T)) ) & \text{otherwise}
+\end{cases}
 \end{eqnarray}
 
 The signed transaction $G(T, p_{\mathrm{r}})$ is defined as:
 \begin{eqnarray}
 G(T, p_{\mathrm{r}}) \equiv T \quad \text{except:} \\
-(T_{\mathrm{w}}, T_{\mathrm{r}}, T_{\mathrm{s}}) = \mathtt{ECDSASIGN}(h(T), p_{\mathrm{r}})
+(T_{\mathrm{y}}, T_{\mathrm{r}}, T_{\mathrm{s}}) = \mathtt{ECDSASIGN}(h(T), p_{\mathrm{r}})
 \end{eqnarray}
 
 \hyperlink{T__w_T__r_T__s}{Reiterating from previously}:
@@ -1874,14 +1926,15 @@ G(T, p_{\mathrm{r}}) \equiv T \quad \text{except:} \\
 \linkdest{T__r}{T_{\mathrm{r}}} = \hyperlink{r}{r}\\
 \linkdest{T__s}{T_{\mathrm{s}}} = \hyperlink{s}{s}
 \end{eqnarray}
-$\linkdest{T__w}{T_{\mathrm{w}}}$ is either the recovery identifier or `chain identifier \hyperlink{chain_id}{$\beta$} doubled plus 35 or 36'.  In the second case, where \hypertarget{v}{}$v$ is the chain identifier $\beta$ doubled plus 35 or 36, the values 35 and 36 assume the role of the `recovery identifier' by specifying the parity of $y$, with the value 35 representing an even value and 36 representing an odd value.
+and $\linkdest{T__w}{T_{\mathrm{w}}}$ of legacy transcations is either $27 + T_{\mathrm{y}}$ or $2\hyperlink{chain_id}{\beta} + 35 + T_{\mathrm{y}}$.
 
 We may then define the sender function $S$ of the transaction as:
 \begin{eqnarray}
-S(T) &\equiv& \mathcal{B}_{96..255}\big(\mathtt{KEC}\big( \mathtt{ECDSARECOVER}(h(T), v_0, T_{\mathrm{r}}, T_{\mathrm{s}}) \big) \big) \\
-v_0 &\equiv& \begin{cases}
-T_{\mathrm{w}} &\text{if}\ T_{\mathrm{w}}\in\{27, 28\} \\
-28 - (T_{\mathrm{w}} \bmod 2) &\text{otherwise}
+S(T) &\equiv& \mathcal{B}_{96..255}\big(\mathtt{KEC}\big( \mathtt{ECDSARECOVER}(h(T), v, T_{\mathrm{r}}, T_{\mathrm{s}}) \big) \big) \\
+v &\equiv& \begin{cases}
+T_{\mathrm{w}} - 27 & \text{if} \; T_{\mathrm{x}} = 0 \land T_{\mathrm{w}} \in \{27, 28\} \\
+(T_{\mathrm{w}}-35) \bmod 2 & \text{if} \ T_{\mathrm{x}} = 0 \land T_{\mathrm{w}} \in \{2\beta + 35, 2\beta + 36\} \\
+T_{\mathrm{y}} & \text{if} \ T_{\mathrm{x}} = 1
 \end{cases}
 \end{eqnarray}
 

--- a/Paper.tex
+++ b/Paper.tex
@@ -326,7 +326,7 @@ All transaction types specify a number of common fields:
 EIP-2930 (type 1) transactions also have:
 \begin{description}
 \item[accessList]\linkdest{tx_access_list}{} List of access entries to warm up; formally $T_{\mathbf{A}}$.
-Each access list entry $A$ is a tuple of an account address and a list of storage keys: $A \equiv (A_{\mathrm{a}}, A_{\mathbf{s}})$. 
+\linkdest{access_list_entry}{}Each access list entry $E$ is a tuple of an account address and a list of storage keys: $E \equiv (E_{\mathrm{a}}, E_{\mathbf{s}})$. 
 \item[chainId]\linkdest{tx_chain_id}{} Chain ID; formally $T_{\mathrm{c}}$. Must be equal to the network chain ID \hyperlink{chain_id}{$\beta$}.
 \item[yParity]\linkdest{tx_y_parity}{} Signature Y parity; formally $T_{\mathrm{y}}$.
 \end{description}
@@ -741,8 +741,8 @@ Evaluating $\boldsymbol{\sigma}_{\mathrm{P}}$ from $\boldsymbol{\sigma}_0$ depen
 where
 \begin{align}
 A^* & \equiv A^0 \quad \text{except} \\
-A^*_{\mathbf{a}} & \equiv A^0_{\mathbf{a}} \cup \{S(T)\} \cup \{ T_{\mathbf{A}}[i]_{\mathrm{a}}, \; i < \lVert T_{\mathbf{A}} \rVert \} \\
-A^*_{\mathbf{K}} & \equiv \bigcup_{i = 0}^{\lVert T_{\mathbf{A}} \rVert - 1} \{ (T_{\mathbf{A}}[i]_{\mathrm{a}}, T_{\mathbf{A}}[i]_{\mathbf{s}}[j]), \; j < \lVert T_{\mathbf{A}}[i]_{\mathbf{s}} \rVert \}
+A^*_{\mathbf{a}} & \equiv A^0_{\mathbf{a}} \cup \{S(T)\} \cup_{E \in T_{\mathbf{A}}} \{ \hyperlink{access_list_entry}{E}_{\mathrm{a}} \} \\
+A^*_{\mathbf{K}} & \equiv \bigcup_{E \in T_{\mathbf{A}}} \big\{ \forall i < \lVert E_{\mathbf{s}} \rVert, i \in \mathbb{N}: \; (E_{\mathrm{a}}, E_{\mathbf{s}}[i]) \big\}
 \end{align}
 and $g$ is the amount of gas remaining after deducting the basic amount required to pay for the existence of the transaction:
 \begin{equation}

--- a/Paper.tex
+++ b/Paper.tex
@@ -486,7 +486,7 @@ where $p_{\mathrm{T}}(k, v)$ and $p_{\mathrm{R}}(k, v)$ are pairwise RLP transfo
 \begin{equation}
 p_{\mathrm{T}}(k, T) \equiv \left( \mathtt{RLP}(k), \begin{cases}
 \mathtt{RLP}(\hyperlink{L_transaction}{L_{\mathrm{T}}}(T)) & \text{if} \quad T_{\mathrm{x}} = 0 \\
-T_{\mathrm{x}} \cdot \mathtt{RLP}(L_{\mathrm{T}}(T)) & \text{otherwise}
+(T_{\mathrm{x}}) \cdot \mathtt{RLP}(L_{\mathrm{T}}(T)) & \text{otherwise}
 \end{cases}
 \right)
 \end{equation}
@@ -494,7 +494,7 @@ and
 \begin{equation}
 p_{\mathrm{R}}(k, R) \equiv \left( \mathtt{RLP}(k), \begin{cases}
 \mathtt{RLP}(\hyperlink{L__R}{L_{\mathrm{R}}}(R)) & \text{if} \quad R_{\mathrm{x}} = 0 \\
-R_{\mathrm{x}} \cdot \mathtt{RLP}(L_{\mathrm{R}}(R)) & \text{otherwise}
+(R_{\mathrm{x}}) \cdot \mathtt{RLP}(L_{\mathrm{R}}(R)) & \text{otherwise}
 \end{cases}
 \right)
 \end{equation}
@@ -521,7 +521,7 @@ where $\widetilde{L}_{\mathrm{T}}$ takes a special care of EIP-2718 transactions
 \begin{equation}
 \widetilde{L}_{\mathrm{T}}(T) = \begin{cases}
 \hyperlink{L_transaction}{L_{\mathrm{T}}}(T) & \text{if} \quad T_{\mathrm{x}} = 0 \\
-T_{\mathrm{x}} \cdot \mathtt{RLP}(L_{\mathrm{T}}(T)) & \text{otherwise}
+(T_{\mathrm{x}}) \cdot \mathtt{RLP}(L_{\mathrm{T}}(T)) & \text{otherwise}
 \end{cases}
 \end{equation}
 \hypertarget{general_element_wise_sequence_transformation_f_pow_asterisk}{}with $\widetilde{L}_{\mathrm{T}}^*$ and $L_{\mathrm{H}}^*$ being element-wise sequence transformations, thus:
@@ -1008,8 +1008,8 @@ It is assumed that the client will have stored the pair $(\mathtt{KEC}(I_{\mathb
 As can be seen, there are nine exceptions to the usage of the general execution framework $\Xi$ for evaluation of the message call: these are so-called `precompiled' contracts, meant as a preliminary piece of architecture that may later become \textit{native extensions}.
 The contracts in addresses 1 to 9 execute the elliptic curve public key recovery function, the SHA2 256-bit hash scheme, the RIPEMD 160-bit hash scheme, the identity function, arbitrary precision modular exponentiation, elliptic curve addition, elliptic curve scalar multiplication, an elliptic curve pairing check, and the BLAKE2 compression function $\mathtt{F}$ respectively.
 Their full formal definition is in Appendix \ref{app:precompiled}.
-We denote the set of the addresses of the precompiled contracts by $\pi$:
-\begin{equation}\hypertarget{precompiled_set}{}
+\hypertarget{precompiled_set}{}We denote the set of the addresses of the precompiled contracts by $\pi$:
+\begin{equation}
 \pi \equiv \{1, 2, 3, 4, 5, 6, 7, 8, 9 \}
 \end{equation}
 

--- a/Paper.tex
+++ b/Paper.tex
@@ -320,7 +320,7 @@ All transaction types specify a number of common fields:
 \item[gasLimit]\linkdest{tx_gas_limit_T__g}{} A scalar value equal to the maximum amount of gas that should be used in executing this transaction. This is paid up-front, before any computation is done and may not be increased later; formally $T_{\mathrm{g}}$.
 \item[to]\linkdest{tx_to_address_T__t}{} The 160-bit address of the message call's recipient or, for a contract creation transaction, $\varnothing$, used here to denote the only member of $\mathbb{B}_0$ ; formally $T_{\mathrm{t}}$.
 \item[value]\linkdest{tx_value_T__v}{} A scalar value equal to the number of Wei to be transferred to the message call's recipient or, in the case of contract creation, as an endowment to the newly created account; formally $T_{\mathrm{v}}$.
-\item[r, s] Values corresponding to the signature of the transaction and used to determine the sender of the transaction; formally {$T_{\mathrm{r}}$ and $T_{\mathrm{s}}$}. This is expanded in Appendix \ref{app:signing}.
+\item[r, s]\linkdest{T__r_T__s}{} Values corresponding to the signature of the transaction and used to determine the sender of the transaction; formally {$T_{\mathrm{r}}$ and $T_{\mathrm{s}}$}. This is expanded in Appendix \ref{app:signing}.
 \end{description}
 
 EIP-2930 (type 1) transactions also have:
@@ -332,7 +332,7 @@ EIP-2930 (type 1) transactions also have:
 
 Legacy transactions do not have an \textbf{accessList}, while \textbf{chainId} and \textbf{yParity} for legacy transactions are combined into a single value:
 \begin{description}
-\item[w] A scalar value encoding Y parity and possibly chain ID; \linkdest{T__w_T__r_T__s}formally $T_{\mathrm{w}}$.
+\item[w]\linkdest{T__w}{} A scalar value encoding Y parity and possibly chain ID; formally $T_{\mathrm{w}}$.
 $T_{\mathrm{w}} = 27 + T_{\mathrm{y}}$ or $T_{\mathrm{w}} = 2\beta + 35 + T_{\mathrm{y}}$ (see EIP-155 by \cite{EIP-155}).
 \end{description}
 
@@ -1933,12 +1933,12 @@ G(T, p_{\mathrm{r}}) \equiv T \quad \text{except:} \\
 (T_{\mathrm{y}}, T_{\mathrm{r}}, T_{\mathrm{s}}) = \mathtt{ECDSASIGN}(h(T), p_{\mathrm{r}})
 \end{eqnarray}
 
-\hyperlink{T__w_T__r_T__s}{Reiterating from previously}:
+\hyperlink{T__r_T__s}{Reiterating from previously}:
 \begin{eqnarray}
 \linkdest{T__r}{T_{\mathrm{r}}} = \hyperlink{r}{r}\\
 \linkdest{T__s}{T_{\mathrm{s}}} = \hyperlink{s}{s}
 \end{eqnarray}
-and $\linkdest{T__w}{T_{\mathrm{w}}}$ of legacy transcations is either $27 + T_{\mathrm{y}}$ or $2\hyperlink{chain_id}{\beta} + 35 + T_{\mathrm{y}}$.
+and $\hyperlink{T__w}{T_{\mathrm{w}}}$ of legacy transcations is either $27 + T_{\mathrm{y}}$ or $2\hyperlink{chain_id}{\beta} + 35 + T_{\mathrm{y}}$.
 
 We may then define the sender function $S$ of the transaction as:
 \begin{eqnarray}

--- a/Paper.tex
+++ b/Paper.tex
@@ -1961,6 +1961,8 @@ $G_{\mathrm{low}}$ & 5 & Amount of gas to pay for operations of the set {\small 
 $G_{\mathrm{mid}}$ & 8 & Amount of gas to pay for operations of the set {\small $W_{\mathrm{mid}}$}. \\
 $G_{\mathrm{high}}$ & 10 & Amount of gas to pay for operations of the set {\small $W_{\mathrm{high}}$}. \\
 $G_{\mathrm{warmaccess}}$ & 100 & Cost of a warm account or storage access. \\
+$G_{\mathrm{accesslistaddress}}$ & 2400 & Cost of warming up an account with the access list. \\
+$G_{\mathrm{accessliststorage}}$ & 1900 & Cost of warming up a storage with the access list. \\
 $G_{\mathrm{coldaccountaccess}}$ & 2600 & Cost of a cold account access. \\
 $G_{\mathrm{coldsload}}$ & 2100 & Cost of a cold storage access. \\
 $G_{\mathrm{sset}}$ & 20000 & Paid for an {\small SSTORE} operation when the storage value is set to non-zero from zero. \\
@@ -1988,7 +1990,7 @@ $G_{\mathrm{logtopic}}$ & 375 & Paid for each topic of a {\small LOG} operation.
 $G_{\mathrm{keccak256}}$ & 30 & Paid for each {\small KECCAK256} operation. \\
 $G_{\mathrm{keccak256word}}$ & 6 & Paid for each word (rounded up) for input data to a {\small KECCAK256} operation. \\
 $G_{\mathrm{copy}}$ & 3 & Partial payment for {\small *COPY} operations, multiplied by words copied, rounded up. \\
-$G_{\mathrm{blockhash}}$ & 20 & Payment for {\small BLOCKHASH} operation. \\
+$G_{\mathrm{blockhash}}$ & 20 & Payment for each {\small BLOCKHASH} operation. \\
 
 %extern u256 const c_{\mathrm{copyGas}};			///< Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added.
 \bottomrule

--- a/Paper.tex
+++ b/Paper.tex
@@ -419,12 +419,20 @@ B \equiv (B_{\mathrm{H}}, B_{\mathbf{T}}, B_{\mathbf{U}})
 In order to encode information about a transaction concerning which it may be useful to form a zero-knowledge proof, or index and search, we encode a receipt of each transaction containing certain information from its execution.
 Each receipt, denoted $B_{\mathbf{R}}[i]$ for the $i$th transaction, is placed in an index-keyed \hyperlink{trie}{trie} and the root recorded in the header as \hyperlink{Receipts_Root_H__e}{$H_{\mathrm{e}}$}.
 
-\linkdest{transaction_receipt_R}{}\linkdest{tx_receipt_gas_used_R__u}{}\linkdest{R__u}The transaction receipt, $R$, is a tuple of four items comprising:
+\linkdest{transaction_receipt_R}{}\linkdest{tx_receipt_gas_used_R__u}{}\linkdest{R__u}The transaction receipt, $R$, is a tuple of five items comprising:
+the type of the transaction, $R_{\mathrm{x}}$,
 the status code of the transaction, $R_{\mathrm{z}}$,
 the cumulative gas used in the block containing the transaction receipt as of immediately after the transaction has happened, $R_{\mathrm{u}}$,
 the set of logs created through execution of the transaction, \hyperlink{RLP_serialisation_of_a_sequence_of_other_items_R__l_math_def}{$R_\mathbf{l}$} and the Bloom filter composed from information in those logs, \hyperlink{RLP_serialisation_of_a_byte_array_R__b_math_def}{$R_{\mathrm{b}}$}:
 \begin{equation}
-R \equiv (R_{\mathrm{z}}, R_{\mathrm{u}}, R_{\mathrm{b}}, R_{\mathbf{l}})
+R \equiv (R_{\mathrm{x}}, R_{\mathrm{z}}, R_{\mathrm{u}}, R_{\mathrm{b}}, R_{\mathbf{l}})
+\end{equation}
+
+$R_{\mathrm{x}}$ is equal to the \hyperlink{tx_type}{type} of the corresponding transaction.
+
+\linkdest{L__R}The function $L_{\mathrm{R}}$ prepares a transaction receipt for being transformed into an RLP-serialised byte array:
+\begin{equation}
+L_{\mathrm{R}}(R) \equiv (R_{\mathrm{z}}, R_{\mathrm{u}}, R_{\mathrm{b}}, R_{\mathbf{l}})
 \end{equation}
 
 \linkdest{R__z_assert}We assert that the status code $R_{\mathrm{z}}$ is a non-negative integer:
@@ -468,20 +476,24 @@ Notably, it treats $\mathbf{x}$ as big-endian (more significant bits will have s
 \begin{array}[t]{lclc}
 \linkdest{new_state_H__r}{}H_{\mathrm{r}} &\equiv& \mathtt{TRIE}(L_S(\Pi(\boldsymbol{\sigma}, B))) & \wedge \\
 \linkdest{Ommer_block_hash_H__o}{}H_{\mathrm{o}} &\equiv& \mathtt{KEC}(\mathtt{RLP}(L_H^*(B_{\mathbf{U}}))) & \wedge \\
-\linkdest{tx_block_hash_H__t}{}H_{\mathrm{t}} &\equiv& \mathtt{TRIE}(\{\forall i < \lVert B_{\mathbf{T}} \rVert, i \in \mathbb{N}: &\\&& \quad\quad p'(i, B_{\mathbf{T}}[i])\}) & \wedge \\
-\linkdest{Receipts_Root_H__e}{}H_{\mathrm{e}} &\equiv& \mathtt{TRIE}(\{\forall i < \lVert B_{\mathbf{R}} \rVert, i \in \mathbb{N}: &\\&& \quad\quad p(i, B_{\mathbf{R}}[i])\}) & \wedge \\
+\linkdest{tx_block_hash_H__t}{}H_{\mathrm{t}} &\equiv& \mathtt{TRIE}(\{\forall i < \lVert B_{\mathbf{T}} \rVert, i \in \mathbb{N}: &\\&& \quad\quad p_{\mathrm{T}}(i, B_{\mathbf{T}}[i])\}) & \wedge \\
+\linkdest{Receipts_Root_H__e}{}H_{\mathrm{e}} &\equiv& \mathtt{TRIE}(\{\forall i < \lVert B_{\mathbf{R}} \rVert, i \in \mathbb{N}: &\\&& \quad\quad p_{\mathrm{R}}(i, B_{\mathbf{R}}[i])\}) & \wedge \\
 \linkdest{logs_Bloom_filter_H__b}{}H_{\mathrm{b}} &\equiv& \bigvee_{\mathbf{r} \in B_{\mathbf{R}}} \big( \mathbf{r}_{\mathrm{b}} \big)
 \end{array}
 \end{equation}
-where $p(k, v)$ is simply the pairwise RLP transformation, in this case, the first being the index of the transaction in the block and the second being the transaction receipt:
+where $p_{\mathrm{T}}(k, v)$ and $p_{\mathrm{R}}(k, v)$ are pairwise RLP transformations, but with a special treatment for EIP-2718 transactions:
 \begin{equation}
-p(k, v) \equiv \big( \mathtt{RLP}(k), \mathtt{RLP}(v) \big)
-\end{equation}
-and $p'(k, T)$ is similar, but has a special treatment for EIP-2718 transactions:
-\begin{equation}
-p'(k, T) \equiv \left( \mathtt{RLP}(k), \begin{cases}
-\mathtt{RLP}(L_{\mathrm{T}}(T)) & \text{if} \quad T_{\mathrm{x}} = 0 \\
+p_{\mathrm{T}}(k, T) \equiv \left( \mathtt{RLP}(k), \begin{cases}
+\mathtt{RLP}(\hyperlink{L_transaction}{L_{\mathrm{T}}}(T)) & \text{if} \quad T_{\mathrm{x}} = 0 \\
 T_{\mathrm{x}} \cdot \mathtt{RLP}(L_{\mathrm{T}}(T)) & \text{otherwise}
+\end{cases}
+\right)
+\end{equation}
+and
+\begin{equation}
+p_{\mathrm{R}}(k, R) \equiv \left( \mathtt{RLP}(k), \begin{cases}
+\mathtt{RLP}(\hyperlink{L__R}{L_{\mathrm{R}}}(R)) & \text{if} \quad R_{\mathrm{x}} = 0 \\
+R_{\mathrm{x}} \cdot \mathtt{RLP}(L_{\mathrm{R}}(R)) & \text{otherwise}
 \end{cases}
 \right)
 \end{equation}


### PR DESCRIPTION
This finishes the update of the YP to [Berlin](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md) (first part in PR #817). Namely, this PR includes:
- [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718): Typed Transaction Envelope
- [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930): Optional access lists

Here's the rendered PDF:
[EIP-2930 Paper.pdf](https://github.com/ethereum/yellowpaper/files/7881023/EIP-2930.Paper.pdf)

