### PR TITLE
9.4.3. Jump Destination Validity - be explicit about validation

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1147,7 +1147,7 @@ The last condition was introduced in EIP-1706 by \cite{EIP-1706} (part of EIP-22
 
 We previously used $D$ as the function to determine the set of valid jump destinations given the code that is being run. We define this as any position in the code occupied by a {\small JUMPDEST} instruction.
 
-All such positions must be on valid instruction boundaries, rather than sitting in the data portion of {\small PUSH} operations and must appear within the explicitly defined portion of the code (rather than in the implicitly defined \hyperlink{stop}{{\small STOP}} operations that trail it).
+All such positions must be on valid instruction boundaries, rather than sitting in the data portion of {\small PUSH} operations and must appear within the explicitly defined portion of the code (rather than in the implicitly defined \hyperlink{stop}{{\small STOP}} operations that trail it), where code denotes any executable code or data (non-reachable by Program Counter) between {\small PUSH} operations. Jump destinations must be validated prior to execution.
 
 Formally:
 \begin{equation}


### PR DESCRIPTION
The sentence "must appear within the explicitly defined portion of the code"
leads the reader to think that only executable code is checked for JUMPDEST validity.
In practice, all clients validate jump destinations prior to execution.

The problem was detailed in https://github.com/ethereum/yellowpaper/issues/840.