### PR TITLE
Fix the upsidedown multiplier in the bloom filter footnote

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -460,7 +460,7 @@ We define the Bloom filter function, $M$, to reduce a log entry into a single 25
 \begin{equation}
 M(O) \equiv \hyperlink{bigvee}{\bigvee}_{x \in \{O_{\mathrm{a}}\} \cup O_{\mathbf{t}}} \big( M_{3:2048}(x) \big)
 \end{equation}
-where $M_{3:2048}$ is a specialised Bloom filter that sets three bits out of 2048, given an arbitrary byte sequence. It does this through taking the low-order 11 bits of each of the first three pairs of bytes in a Keccak-256 hash of the byte sequence.\footnote{11 bits $= 2^{2048}$, and the low-order 11 bits is the modulo 2048 of the operand, which is in this case is "each of the first three pairs of bytes in a Keccak-256 hash of the byte sequence."} Formally:
+where $M_{3:2048}$ is a specialised Bloom filter that sets three bits out of 2048, given an arbitrary byte sequence. It does this through taking the low-order 11 bits of each of the first three pairs of bytes in a Keccak-256 hash of the byte sequence.\footnote{2048 $= 2^{11}$(11 bits), and the low-order 11 bits is the modulo 2048 of the operand, which is in this case is "each of the first three pairs of bytes in a Keccak-256 hash of the byte sequence."} Formally:
 \begin{eqnarray}
 M_{3:2048}(\mathbf{x}: \mathbf{x} \in \mathbb{B}) & \equiv & \mathbf{y}: \mathbf{y} \in \mathbb{B}_{256} \quad \text{where:}\\
 \mathbf{y} & = & (0, 0, ..., 0) \quad \text{except:}\\


### PR DESCRIPTION
<img width="420" alt="스크린샷 2022-02-21 오후 3 46 57" src="https://user-images.githubusercontent.com/55133749/154903041-b7d207d3-dedd-4018-b3cb-0d3fa21d04eb.png">
The operation of the bloom filter is explained in the image above.

I fix the upsidedown multiplier in the bloom filter footnote.
Before:
<img width="866" alt="스크린샷 2022-02-21 오후 3 48 53" src="https://user-images.githubusercontent.com/55133749/154903347-4367469e-e4ed-481b-9620-fc9a86863cff.png">
After:
<img width="866" alt="스크린샷 2022-02-21 오후 3 46 10" src="https://user-images.githubusercontent.com/55133749/154902965-919955ed-dcfc-4b78-bd8b-adc277dc9a93.png">



