### PR TITLE
Don't cite withdrawn EIP-1706

### DIFF
--- a/Biblio.bib
+++ b/Biblio.bib
@@ -140,13 +140,6 @@ and Gilles Van Assche",
 	year = "2019",
 }
 
-@Misc{EIP-1706,
-	url = "https://eips.ethereum.org/EIPS/eip-1706",
-	title = "{EIP}-1706: Disable SSTORE with gasleft lower than call stipend ",
-	author = "Forshtat, Alex and Weiss, Yoav",
-	year = "2019",
-}
-
 @Misc{EIP-2200,
 	url = "https://eips.ethereum.org/EIPS/eip-2200",
 	title = "{EIP}-2200: Structured Definitions for Net Gas Metering",

--- a/Paper.tex
+++ b/Paper.tex
@@ -1142,8 +1142,8 @@ w = \text{\small CALL} \; \wedge \; \boldsymbol{\mu}_{\mathbf{s}}[2] \neq 0
 \end{equation}
 
 This states that the execution is in an exceptional halting state if there is insufficient gas, if the instruction is invalid (and therefore its $\delta$ subscript is undefined), if there are insufficient stack items, if a {\small JUMP}/{\small JUMPI} destination is invalid, the new stack size would be larger than 1024 or state modification is attempted during a static call. The astute reader will realise that this implies that no instruction can, through its execution, cause an exceptional halt.
-Also, the execution is in an exceptional halting state if the gas left prior to executing an \hyperlink{SSTORE}{{\small SSTORE}} instruction is less than or equal to the call stipend $\hyperlink{G__callstipend}{G_{\mathrm{callstipend}}}$.
-The last condition was introduced in EIP-1706 by \cite{EIP-1706} (part of EIP-2200 by \cite{EIP-2200}).
+Also, the execution is in an exceptional halting state if the gas left prior to executing an \hyperlink{SSTORE}{{\small SSTORE}} instruction is less than or equal to the call stipend $\hyperlink{G__callstipend}{G_{\mathrm{callstipend}}}$
+-- see EIP-2200 by \cite{EIP-2200} for more information.
 
 \subsubsection{Jump Destination Validity}
 


### PR DESCRIPTION
Don't cite withdrawn [EIP-1706](https://eips.ethereum.org/EIPS/eip-1706). Cite [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) instead (EIP-1706 is a part of EIP-2200).