### PR TITLE
Fix ambiguous empty brackets in Appendix D

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1591,7 +1591,7 @@ We define the function $\texttt{TRIE}$, which evaluates to the root of the trie 
 We also assume a function $n$, the trie's node cap function. When composing a node, we use RLP to encode the structure. As a means of reducing storage complexity, we store nodes whose composed RLP is fewer than 32 bytes directly; for those larger we assert prescience of the byte array whose Keccak-256 hash evaluates to our reference. Thus we define in terms of $c$, the node composition function:
 \begin{equation}
 n(\mathfrak{I}, i) \equiv \begin{cases}
-() & \text{if} \quad \mathfrak{I} = \varnothing \\
+() \in \mathbb{B} & \text{if} \quad \mathfrak{I} = \varnothing \\
 c(\mathfrak{I}, i) & \text{if} \quad \lVert \, \texttt{RLP} \big( c(\mathfrak{I}, i) \big) \rVert < 32 \\
 \texttt{KEC}\big(\texttt{RLP}( c(\mathfrak{I}, i)) \big) & \text{otherwise}
 \end{cases}
@@ -1613,7 +1613,7 @@ c(\mathfrak{I}, i) \equiv \begin{cases}
 u(j) & \equiv & n(\{ I : I \in \mathfrak{I} \wedge I_0[i] = j \}, i + 1) \\
 v & = & \begin{cases}
 I_1 & \text{if} \quad \exists I: I \in \mathfrak{I} \wedge \lVert I_0 \rVert = i \\
-() & \text{otherwise}
+() \in \mathbb{B} & \text{otherwise}
 \end{cases}
 \end{array}
 \end{cases}


### PR DESCRIPTION
Appendix B (Recursive Length Prefix) defines two sets of possible inputs to the RLP function: lists and byte arrays.
![image](https://user-images.githubusercontent.com/7281754/161761868-e2af87f9-9655-44d9-9338-40b5aa80d2c6.png)

An empty list must be distinguishable from an empty byte array because RLP of an empty list is (0xC0) while RLP of an empty byte array is (0x80).

Appendix D (Modified Merkle Patricia Tree) uses empty round brackets in two equations. In both cases it is unclear whether these empty round brackets represent an empty list or an empty byte array. It should be fixed in this PR.
![image](https://user-images.githubusercontent.com/7281754/161762889-ed7a2137-d723-4afa-8874-5bb7549018ee.png)
![image](https://user-images.githubusercontent.com/7281754/161762993-916fb3cc-a2b0-4ca1-acfa-b260d5fceae9.png)

In both cases, these empty brackets should represent an empty byte array, which I checked against geth source code (https://github.com/ethereum/go-ethereum/blob/5079e3c6e5f2096e32b2216d1119db66fe0ff531/trie/node_enc.go#L37 and https://github.com/ethereum/go-ethereum/blob/5079e3c6e5f2096e32b2216d1119db66fe0ff531/trie/node_enc.go#L49).

Modified equations look like this:
![image](https://user-images.githubusercontent.com/7281754/161764358-4fdd48ef-4e80-486e-bc8a-7a62c58d8ecb.png)
![image](https://user-images.githubusercontent.com/7281754/161764460-ec29ec80-2273-4333-b0e5-75e5f4277b15.png)
