### PR TITLE
Explain that ecrecover only accepts v={27,28}

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -1640,7 +1640,7 @@ We define $\Xi_{\mathtt{ECREC}}$ as a precompiled contract for the elliptic curv
 \begin{eqnarray}
 \Xi_{\mathtt{ECREC}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{where:} \\
 g_{\mathrm{r}} &=& 3000\\
-\lVert \mathbf{o} \rVert &=& \begin{cases} 0 & \text{if} \quad \mathtt{v} \neq 27 \wedge \mathtt{v} \neq 28 \\ 0 & \text{if} \quad \mathtt{ECDSARECOVER}(h, v, r, s) = \varnothing\\ 32 & \text{otherwise} \end{cases}\\
+\lVert \mathbf{o} \rVert &=& \begin{cases} 0 & \text{if} \quad \mathtt{v} \neq 27 \wedge \mathtt{v} \neq 28 \\ 0 & \text{if} \quad \mathtt{ECDSARECOVER}(h, v - 27, r, s) = \varnothing\\ 32 & \text{otherwise} \end{cases}\\
 \text{if} \quad \lVert \mathbf{o} \rVert = 32: &&\\
 \mathbf{o}[0..11] &=& 0 \\
 \mathbf{o}[12..31] &=& \mathtt{KEC}\big(\mathtt{ECDSARECOVER}(h, v - 27, r, s)\big)[12..31] \quad \text{where:}\\

--- a/Paper.tex
+++ b/Paper.tex
@@ -1640,7 +1640,7 @@ We define $\Xi_{\mathtt{ECREC}}$ as a precompiled contract for the elliptic curv
 \begin{eqnarray}
 \Xi_{\mathtt{ECREC}} &\equiv& \Xi_{\mathtt{PRE}} \quad \text{where:} \\
 g_{\mathrm{r}} &=& 3000\\
-\lVert \mathbf{o} \rVert &=& \begin{cases} 0 & \text{if} \quad \mathtt{ECDSARECOVER}(h, v, r, s) = \varnothing\\ 32 & \text{otherwise} \end{cases}\\
+\lVert \mathbf{o} \rVert &=& \begin{cases} 0 & \text{if} \quad \mathtt{v} \neq 27 \wedge \mathtt{v} \neq 28 \\ 0 & \text{if} \quad \mathtt{ECDSARECOVER}(h, v, r, s) = \varnothing\\ 32 & \text{otherwise} \end{cases}\\
 \text{if} \quad \lVert \mathbf{o} \rVert = 32: &&\\
 \mathbf{o}[0..11] &=& 0 \\
 \mathbf{o}[12..31] &=& \mathtt{KEC}\big(\mathtt{ECDSARECOVER}(h, v, r, s)\big)[12..31] \quad \text{where:}\\

--- a/Paper.tex
+++ b/Paper.tex
@@ -1643,7 +1643,7 @@ g_{\mathrm{r}} &=& 3000\\
 \lVert \mathbf{o} \rVert &=& \begin{cases} 0 & \text{if} \quad \mathtt{v} \neq 27 \wedge \mathtt{v} \neq 28 \\ 0 & \text{if} \quad \mathtt{ECDSARECOVER}(h, v, r, s) = \varnothing\\ 32 & \text{otherwise} \end{cases}\\
 \text{if} \quad \lVert \mathbf{o} \rVert = 32: &&\\
 \mathbf{o}[0..11] &=& 0 \\
-\mathbf{o}[12..31] &=& \mathtt{KEC}\big(\mathtt{ECDSARECOVER}(h, v, r, s)\big)[12..31] \quad \text{where:}\\
+\mathbf{o}[12..31] &=& \mathtt{KEC}\big(\mathtt{ECDSARECOVER}(h, v - 27, r, s)\big)[12..31] \quad \text{where:}\\
 \mathbf{d}[0..(\lVert \hyperlink{I__d}{I_{\mathbf{d}}} \rVert-1)] &=& I_{\mathbf{d}}\\
 \mathbf{d}[\lVert I_{\mathbf{d}} \rVert..] &=& (0, 0, ...) \\
 h &=& \mathbf{d}[0..31]\\


### PR DESCRIPTION
Two conditions have been implemented in clients:
1. The leading 31 bytes of the `v` value MUST be 0
2. For the last byte the values 27 and 28 are the only accepted ones

The first condition has been thoroughly tested ([CALLCODEEcrecoverV_prefixedf0](https://github.com/ethereum/tests/blob/develop/src/GeneralStateTestsFiller/stPreCompiledContracts2/CALLCODEEcrecoverV_prefixedf0Filler.json)), the second one partially.

Client implementations:
- Geth: [contracts.go](https://github.com/ethereum/go-ethereum/blob/v1.10.18/core/vm/contracts.go#L179) [crypto.go](https://github.com/ethereum/go-ethereum/blob/v1.10.18/crypto/crypto.go#L272)
- Erigon: [contracts.go](https://github.com/ledgerwatch/erigon/blob/v2022.06.02/core/vm/contracts.go#L203) [crypto.go](https://github.com/ledgerwatch/erigon/blob/v2022.06.02/crypto/crypto.go#L309)
- Nethermind: [EcRecoverPrecompile.cs](https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.Evm/Precompiles/EcRecoverPrecompile.cs#L72)
- ethereumjs: [ecrecover.ts](https://github.com/ethereumjs/ethereumjs-monorepo/blob/%40ethereumjs/vm%405.9.2/packages/vm/src/evm/precompiles/01-ecrecover.ts#L24)
- Besu: [ECRECPrecompiledContract.java](https://github.com/hyperledger/besu/blob/main/evm/src/main/java/org/hyperledger/besu/evm/precompile/ECRECPrecompiledContract.java#L62) [SECPSignature.java](https://github.com/hyperledger/besu/blob/main/crypto/src/main/java/org/hyperledger/besu/crypto/SECPSignature.java#L71)
- openethereum: [builtin](https://github.com/openethereum/openethereum/blob/main/crates/vm/builtin/src/lib.rs#L826)
- execution-specs: [ececover.py](https://github.com/ethereum/execution-specs/blob/master/src/ethereum/homestead/vm/precompiled_contracts/ecrecover.py#L44)
- revm/foundry: [secp256k1.rs](https://github.com/bluealloy/revm/blob/main/crates/revm_precompiles/src/secp256k1.rs#L74)