### PR TITLE
Fix memory linear cost limit: 724B -> 704B

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -2111,7 +2111,7 @@ Note the memory cost component, given as the product of $G_{\mathrm{memory}}$ an
 
 Referencing a zero length range (e.g. by attempting to pass it as the input range to a CALL) does not require memory to be extended to the beginning of the range. $\boldsymbol{\mu}'_{\mathrm{i}}$ is defined as this new maximum number of words of active memory; special-cases are given where these two are not equal.
 
-Note also that $C_{\mathrm{mem}}$ is the memory cost function (the expansion function being the difference between the cost before and after). It is a polynomial, with the higher-order coefficient divided and floored, and thus linear up to 724B of memory used, after which it costs substantially more.
+Note also that $C_{\mathrm{mem}}$ is the memory cost function (the expansion function being the difference between the cost before and after). It is a polynomial, with the higher-order coefficient divided and floored, and thus linear up to 704B of memory used, after which it costs substantially more.
 
 While defining the instruction set, we defined the memory-expansion for range function, $M$, thus:
 


### PR DESCRIPTION

<img width="849" alt="image" src="https://user-images.githubusercontent.com/117736/178642566-c0c7e4b8-281d-4ba7-b65b-529e539cd163.png"> It should be "linear up to 735B", because

<img width="546" alt="image" src="https://user-images.githubusercontent.com/117736/178642178-eec9940e-4ab0-4abc-9d5e-b4b6ad14778d.png">

The "a" in the C_mem function is number of *words*.
We have to do the ceiling/floor first, and convert it to bytes later.
```
>>> math.ceil(math.sqrt(512) * 32) - 1  # wrong formula
724.0

>>> math.ceil(math.sqrt(512)) * 32 - 1  # right formula
735.0
```
Verify:

The non-linear term becomes non-zero at 735/736B, not 724/725B.
```
>>> x = 724; (x / 32) ** 2 / 512
0
>>> x = 725; (x / 32) ** 2 / 512        # still 0, incorrect
0

>>> x = 735; (x / 32) ** 2 / 512
0
>>> x = 736; (x / 32) ** 2 / 512        # becomes non-zero, correct
1
```