### PR TITLE
Tiny Correction for returndata in Create

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -2585,7 +2585,7 @@ G_{\mathrm{sreset}} - G_{\mathrm{warmaccess}} & \text{if} \quad v_0 = v' \; \wed
 &&&& address of the newly created account (\ref{eq:new-address}). \\
 &&&& $\boldsymbol{\mu}'_{\mathrm{i}} \equiv M(\boldsymbol{\mu}_{\mathrm{i}}, \boldsymbol{\mu}_{\mathbf{s}}[1], \boldsymbol{\mu}_{\mathbf{s}}[2])$ \\
 &&&& $\boldsymbol{\mu}'_{\mathbf{o}} \equiv \begin{cases}
-() & \text{if} \quad z = 1 \\
+() & \text{if} \quad z = 0 \\
 \mathbf{o} & \text{otherwise}
 \end{cases}$ \\
 &&&& Thus the operand order is: value, input offset, input size. \\


### PR DESCRIPTION
Based on the definition of z above, where it is `z = 0` in the error case, I think it should be `z = 0` instead of `z = 1` in this part as well. Alternatively, the whole line could simplified as 
```
$\boldsymbol{\mu}'_{\mathbf{o}} = \mathbf{o}$
```