### PR TITLE
YP Out of Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ The Yellow Paper is a formal definition of the Ethereum protocol, originally by 
 
 It is a free culture work, licensed under Creative Commons Attribution Share-Alike (CC-BY-SA) Version 4.0.
 
+## Repository Currently Outdated
+
+The Yellow Paper is out of date. It reflects the Ethereum specification up to the [Berlin](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md) network upgrade, activated on the Ethereum mainnet at block `12_244_000` (April 2021). 
+
+It does **not** contain changes introduced in following network upgrades, including [London](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md), [Paris](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md), or any post-merge upgrade. 
+
+An alternative [Python Execution Layer specification](https://ethereum.github.io/execution-specs/) is actively maintained and up to date. 
+
 ## Usage
 
 If you just want to read the paper, the latest version is generally available as a PDF at https://ethereum.github.io/yellowpaper/paper.pdf. If you find that the borders for links block too much text when viewing the PDF in the browser, you can instead download it and open and view it with a PDF viewer application such as Adobe Acrobat or Evince, where the borders are less likely to display over text.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ It does **not** contain changes introduced in following network upgrades, includ
 
 An alternative [Python Execution Layer specification](https://ethereum.github.io/execution-specs/) is actively maintained and up to date. 
 
+If you would like to update the Yellow Paper to inlcude missing pre-merge network upgrades, you can apply for a grant [here](https://esp.ethereum.foundation/applicants/project-grants/apply). 
+
 ## Usage
 
 If you just want to read the paper, the latest version is generally available as a PDF at https://ethereum.github.io/yellowpaper/paper.pdf. If you find that the borders for links block too much text when viewing the PDF in the browser, you can instead download it and open and view it with a PDF viewer application such as Adobe Acrobat or Evince, where the borders are less likely to display over text.


### PR DESCRIPTION
Highlight that the YP only has support until the Berlin fork to prevent confusion. Redirect people towards the Python spec, which is actively maintained. 

Added a link to the ESP grant page in a second commit, as the EF would fund someone wanting to add support for London + Paris (and the diff bomb forks) to the YP. 