### PR TITLE
Fix tx type in equation (18)

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -395,7 +395,7 @@ T_{\mathbf{d}} & \text{otherwise}
 Here, we assume all components are interpreted by the RLP as integer values, with the exception of the access list $T_{\mathbf{A}}$ and the arbitrary length byte arrays $T_{\mathbf{i}}$ and $T_{\mathbf{d}}$.
 \begin{equation}
 \begin{array}[t]{lclclc}
-T_{\mathrm{x}} \in \{0, 1\} & \wedge & T_{\mathrm{c}} = \beta & \wedge & T_{\mathrm{n}} \in \mathbb{N}_{256} & \wedge \\
+T_{\mathrm{x}} \in \{0, 1, 2\} & \wedge & T_{\mathrm{c}} = \beta & \wedge & T_{\mathrm{n}} \in \mathbb{N}_{256} & \wedge \\
 T_{\mathrm{p}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{g}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{v}} \in \mathbb{N}_{256} & \wedge \\
 T_{\mathrm{w}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{r}} \in \mathbb{N}_{256} & \wedge & T_{\mathrm{s}} \in \mathbb{N}_{256} & \wedge \\
 T_{\mathrm{y}} \in \mathbb{N}_{1} & \wedge & T_{\mathbf{d}} \in \mathbb{B} & \wedge & T_{\mathbf{i}} \in \mathbb{B} & \wedge \\


### PR DESCRIPTION
## TL;DR
| **Before** | **After** |
|-|-|
|![image](https://github.com/ethereum/yellowpaper/assets/5858657/e7fd6fa3-9bbd-4a30-b4e3-9eb7021a9924)|![image](https://github.com/ethereum/yellowpaper/assets/5858657/68f053fc-f3d2-45f2-99d5-1f081714b4eb)|

## Fixing Tx in equation (18)
According to the Yellow Paper itself, `Tx = 2` is valid, but equation (18) states that `Tx` can only be `0` or `1`. I believe this might be a simple mistake, so I have opened this PR to address it. However, it's possible that I have misunderstood this part of the paper. Please feel free to close this PR if that's the case.

In any case, thanks for your work in maintaining the Yellow Paper!
