### PR TITLE
Transaction recipient should be warm

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -825,8 +825,12 @@ Evaluating $\boldsymbol{\sigma}_{\mathrm{P}}$ from $\boldsymbol{\sigma}_0$ depen
 where
 \begin{align}
 A^* & \equiv A^0 \quad \text{except} \\
-A^*_{\mathbf{a}} & \equiv A^0_{\mathbf{a}} \cup \{S(T)\} \cup_{E \in T_{\mathbf{A}}} \{ \hyperlink{access_list_entry}{E}_{\mathrm{a}} \} \\
-A^*_{\mathbf{K}} & \equiv \bigcup_{E \in T_{\mathbf{A}}} \big\{ \forall i < \lVert E_{\mathbf{s}} \rVert, i \in \mathbb{N}: \; (E_{\mathrm{a}}, E_{\mathbf{s}}[i]) \big\}
+A^*_{\mathbf{K}} & \equiv \bigcup_{E \in T_{\mathbf{A}}} \big\{ \forall i < \lVert E_{\mathbf{s}} \rVert, i \in \mathbb{N}: \; (E_{\mathrm{a}}, E_{\mathbf{s}}[i]) \big\} \\
+A^*_{\mathbf{a}} & \equiv \begin{cases}
+a \cup T_{\mathrm{t}} & \text{if} \quad T_{\mathrm{t}} \neq \varnothing \\
+a & \text{otherwise}
+\end{cases} \\
+a & \equiv A^0_{\mathbf{a}} \cup \{S(T)\} \cup_{E \in T_{\mathbf{A}}} \{ \hyperlink{access_list_entry}{E}_{\mathrm{a}} \}
 \end{align}
 and $g$ is the amount of gas remaining after deducting the basic amount required to pay for the existence of the transaction:
 \begin{equation}


### PR DESCRIPTION
# TL;DR
|Before|After|
|-|-|
|![image](https://github.com/ethereum/yellowpaper/assets/5858657/8fcc64fe-5f64-4deb-8dc5-2df6c05e9c24)|![image](https://github.com/ethereum/yellowpaper/assets/5858657/3ab5dc59-657d-4c1d-9169-f49484fd9d08)|

# Problem
The [Berlin](https://ethereum.org/history#berlin) hardfork introduced [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) which is now part of the Yellow Paper specification. This EIP states that the transaction recipient address should be part of the initial accessed account set:
![image](https://github.com/ethereum/yellowpaper/assets/5858657/bbc1187f-5c52-49d8-9767-99805b17aab0)

The Yellow Paper **does** enforce this behavior **only** for contract creation and subsequent xCALL opcodes **but not for the initial message call**.

# Proposed Solution
When the transaction is a message call ($T_t \neq \varnothing$) add the recipient address ($T_t$) to the accessed account set, along with the already present precompiled, sender address, and access list.

---
I would be happy to discuss this further or to make some change to this PR if needed .
Anyway thanks for your time!