### PR TITLE
🐞 fix: Bibliography for Paweł

### DIFF
--- a/Biblio.bib
+++ b/Biblio.bib
@@ -197,7 +197,7 @@ and Gilles Van Assche",
 @Misc{EIP-3541,
 	url = "https://eips.ethereum.org/EIPS/eip-3541",
 	title = "{EIP}-3541: Reject new contract code starting with the 0xEF byte",
-	author = "Beregszaszi, Alex and Bylica, Paweł and Maiboroda, Andrei and Akhunov, Alexey and Reitwiessner, Christian and Swende, Martin",
+	author = "Beregszaszi, Alex and Bylica, Pawe\l{} and Maiboroda, Andrei and Akhunov, Alexey and Reitwiessner, Christian and Swende, Martin",
 	year = "2021",
 	month = "March",
 }


### PR DESCRIPTION
Fixes the rendering of the polish character "ł" in Paweł's name under bibliography.

## Before
![Screenshot from 2024-08-19 10-34-45](https://github.com/user-attachments/assets/3c163563-5bbf-4636-9b51-ff305b807437)

## After
![Screenshot from 2024-08-19 10-34-53](https://github.com/user-attachments/assets/a87d70e7-9928-40c5-8813-982fc4b40a2a)
