### PR TITLE
🐞 fix: Formula for initcode limit

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -848,7 +848,7 @@ where
 and
 \begin{equation}
   n \equiv \begin{cases}
-    \lVert T_{\mathrm{i}} \rVert & \text{if} \; T_{\mathrm{t}} \neq \varnothing \\
+    \lVert T_{\mathrm{i}} \rVert & \text{if} \; T_{\mathrm{t}} = \varnothing \\
     0 & \text{otherwise}
   \end{cases}
 \end{equation}


### PR DESCRIPTION
From the paragraph below the formula:

> The penultimate condition ensures that, for create transactions, the length of the initcode is no greater than 49152 bytes.

The forumula appears inverted; initcode is present only when $T_t = \varnothing$.