### PR TITLE
fix: 32 bytes in the word, not 4

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -2842,7 +2842,7 @@ We employ the following definitions:
 \toprule
 Name & Value & Description \\
 \midrule
-\linkdest{J__wordbytes}{}$J_{\mathrm{wordbytes}}$ & 4  & Bytes in word. \\
+\linkdest{J__wordbytes}{}$J_{\mathrm{wordbytes}}$ & 32 & Bytes in word. \\
 \linkdest{J__datasetinit}{}$J_{\mathrm{datasetinit}}$ & $2^{30}$ & Bytes in dataset at genesis. \\
 \linkdest{J__datasetgrowth}{}$J_{\mathrm{datasetgrowth}}$ & $2^{23}$ & Dataset growth per epoch. \\
 \linkdest{J__cacheinit}{}$J_{\mathrm{cacheinit}}$ & $2^{24}$ & Bytes in cache at genesis. \\


### PR DESCRIPTION
fix: 32 bytes in the word, not 4

Closes https://github.com/ethereum/yellowpaper/issues/925