### PR TITLE
fix(docs): correct grammar in ommersHash field description

### DIFF
--- a/Paper.tex
+++ b/Paper.tex
@@ -451,7 +451,7 @@ and, since the \textit{Shanghai} hard fork, $\mathbf{W}$, a collection of valida
 
 \begin{description}
 \item[parentHash]\linkdest{parent_Hash_H__p_def_words}{} The Keccak 256-bit hash of the parent block's header, in its entirety; formally $H_{\mathrm{p}}$.
-\item[ommersHash] A 256-bit hash field that is now deprecated due to the replacement of proof of work consensus. It is now to a constant, $\texttt{KEC}(\texttt{RLP}(()))$; formally $H_{\mathrm{o}}$.
+\item[ommersHash] A 256-bit hash field that is now deprecated due to the replacement of proof of work consensus. It is now set to a constant, $\texttt{KEC}(\texttt{RLP}(()))$; formally $H_{\mathrm{o}}$.
 \item[beneficiary]\linkdest{beneficiary_H__c}{}\linkdest{H__c} The 160-bit address to which priority fees from this block are transferred; formally $H_{\mathrm{c}}$.
 \item[stateRoot] The Keccak 256-bit hash of the root node of the state trie, after all transactions and withdrawals are executed and finalisations applied; formally $H_{\mathrm{r}}$.
 \item[transactionsRoot] The Keccak 256-bit hash of the root node of the trie structure populated with each transaction in the transactions list portion of the block; formally $H_{\mathrm{t}}$.


### PR DESCRIPTION
Fixed a grammatical issue in the ommersHash description: "It is now to a constant" → "It is now set to a constant".

Closes #937